### PR TITLE
PSG-169: fetch artic-network primer schemes within the ncov dockerfile - ncov optimisation 

### DIFF
--- a/Dockerfile.ncov2019-artic-nf-illumina
+++ b/Dockerfile.ncov2019-artic-nf-illumina
@@ -21,5 +21,9 @@ COPY ncov2019-artic-nf/bin/qc.py /opt/conda/envs/artic-ncov2019-illumina/bin
 
 RUN wget -qO- https://github.com/nextflow-io/nextflow/releases/download/v21.10.6/nextflow | bash && chmod +x nextflow && mv nextflow /usr/bin
 
+# clone the primer schemes so that ncov pipeline does not need to download every time
+RUN mkdir -p /artic-network \
+  && git clone https://github.com/artic-network/primer-schemes.git /artic-network/primer-schemes
+
 COPY . /app
 WORKDIR /app/ncov2019-artic-nf

--- a/Dockerfile.ncov2019-artic-nf-nanopore
+++ b/Dockerfile.ncov2019-artic-nf-nanopore
@@ -21,5 +21,9 @@ COPY ncov2019-artic-nf/bin/qc.py /opt/conda/envs/artic/bin
 
 RUN wget -qO- https://github.com/nextflow-io/nextflow/releases/download/v21.10.6/nextflow | bash && chmod +x nextflow && mv nextflow /usr/bin
 
+# clone the primer schemes so that ncov pipeline does not need to download every time
+RUN mkdir -p /artic-network \
+  && git clone https://github.com/artic-network/primer-schemes.git /artic-network/primer-schemes
+
 COPY . /app
 WORKDIR /app/ncov2019-artic-nf

--- a/covid-pipeline/ncov-custom.config
+++ b/covid-pipeline/ncov-custom.config
@@ -1,7 +1,9 @@
 params {
     // base config
     // Repo to download your primer scheme from
-    schemeRepoURL = 'https://github.com/artic-network/primer-schemes.git'
+    // schemeRepoURL = 'https://github.com/artic-network/primer-schemes.git'
+    // for efficiency, the repo was checked out in our ncov2019-artic-nf docker image
+    schemeRepoURL = '/artic-network/primer-schemes'
     // Directory within schemeRepoURL that contains primer schemes
     schemeDir = 'primer-schemes'
     // Scheme name

--- a/minikube/startup.sh
+++ b/minikube/startup.sh
@@ -6,7 +6,7 @@ wait_for_pod() {
 
     printf "waiting for pod ${__POD} to run "
     while [[ $(kubectl get pods ${__POD} -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do
-        printf "." && sleep 2
+        printf "." && sleep 1
     done
     printf "\n${__POD} is running\n"
 }


### PR DESCRIPTION
Doing so, the ncov2019-artic-nf pipeline does not need to download them every time it runs.
This is advised in the ncov github page: https://github.com/connor-lab/ncov2019-artic-nf/ . 

If we do not do so, we download those primer schemes ~100k per week !

This also enables consistency between executions

As we download the whole repo, we get versions from V1 to V5 included, and not just sars-cov-2.


**note: this is for ncov in general, not just the illumina workflow**