### PR TITLE
PSG-190: fix sample_id when executing the ncov nanopore/medaka workflow

### DIFF
--- a/covid-pipeline/modules/nanopore_match.nf
+++ b/covid-pipeline/modules/nanopore_match.nf
@@ -18,10 +18,18 @@ workflow filter_nanopore_matching_with_metadata{
     main:
         ch_nanopore_search_path = makeNanoporeSearchPath()
 
+        // for this workflow, the sample id is:
+        //   20200311_1427_X1_FAK72834_a3787181_barcode07
+        // where the corresponding fastq file is something like:
+        //   /data/medaka_input/20200311_1427_X1_FAK72834_a3787181/fastq_pass/barcode07/FAK72834_pass_barcode07_298b7829_0.fastq
         Channel
             .fromPath(ch_nanopore_search_path)
-            .map { file -> tuple(file.simpleName, file) }
+            .map { file -> tuple(
+                file.parent.parent.parent.baseName + '_' + file.parent.baseName,
+                file
+            ) }
             .set{ ch_nanopore_files }
+        // ch_nanopore_files.subscribe { println it }
 
         ch_nanopore_files
             .map { it ->  it[0] }

--- a/covid-pipeline/modules/utils.nf
+++ b/covid-pipeline/modules/utils.nf
@@ -1,8 +1,15 @@
 import java.nio.file.Paths
 
 
+/* return the name of the last dir (e.g. /a/b/c/d => d) */
+def getDirName (myDir) {
+    pathDir = Paths.get(myDir)
+    dirName = pathDir.getFileName().toString()
+    return dirName
+}
+
 /* make a glob for retrieving illumina fastq files */
-def makeFastqSearchPath ( illuminaPrefixes, illuminaSuffixes, fastq_exts ) {
+def makeFastqSearchPath (illuminaPrefixes, illuminaSuffixes, fastq_exts) {
     def fastqSearchPath = []
 
     for (suff in illuminaSuffixes) {
@@ -25,7 +32,7 @@ def makeFastqSearchPath ( illuminaPrefixes, illuminaSuffixes, fastq_exts ) {
 /* make a glob for retrieving nanopore-medaka fastq files */
 def makeNanoporeSearchPath ( ) {
     // note: we need this specific extension
-    filePathGlob = params.directory.replaceAll(/\/+$/, "") + '**' + '/*.fastq.gz'
+    filePathGlob = params.directory.replaceAll(/\/+$/, "") + '/fastq_pass/barcode*/*.fastq'
     return filePathGlob
 }
 

--- a/covid-pipeline/nextflow.config
+++ b/covid-pipeline/nextflow.config
@@ -36,9 +36,6 @@ env {
 }
 
 params {
-    // parameters for ncov2019_artic_nf process
-    ncov_prefix = "covid_test"
-
     // parameter for process concatenate_fasta
     // path within container covid-pipeline:${env.VERSION}
     root_genome_fasta = "/app/data/FASTA/SARS-CoV-2.fasta"
@@ -149,9 +146,6 @@ process {
     }
 
     if ( params.ncov2019_artic_workflow == "medaka" ) {
-        withName:decompress_fastq_files {
-            container = "covid-pipeline:${env.VERSION}"
-        }
         withName:append_metadata_match_to_sample_file {
             container = "covid-pipeline:${env.VERSION}"
         }


### PR DESCRIPTION
With this PR, we expect the input data for nanopore/medaka as in their original test code: https://github.com/connor-lab/ncov2019-artic-nf/blob/master/.github/scripts/test_nanopore_pipelines.sh. 

See test example for the input data structure here: s3://synthetic-data-dev/UKHSA/piero-test-data/medaka_fastq_fail/20200311_1427_X1_FAK72834_a3787181/ 

See documentation and tests in ticket: https://jira.congenica.net/browse/PSG-190

1.  remove `decompress_fastq_files` process as no longer app
2. use a specific prefix for nanopore/medaka workflow
3. move input files to barcode folders, so that ncov nanopore/medaka workflow finds the input files as expected