### PR TITLE
PSG-210: setup memory and cpu limits per process

### DIFF
--- a/covid-pipeline/ncov-illumina-k8s.config
+++ b/covid-pipeline/ncov-illumina-k8s.config
@@ -10,50 +10,60 @@ process {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_illumina:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "2 GB"
+        errorStrategy = "ignore"
     }
     withName:articDownloadScheme {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_illumina:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "500 MB"
+        errorStrategy = "ignore"
     }
     withName:indexReference {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_illumina:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "2 GB"
+        errorStrategy = "ignore"
     }
     withName:writeQCSummaryCSV {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_illumina:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "500 MB"
+        errorStrategy = "ignore"
     }
     withName:readMapping {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_illumina:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "2 GB"
+        errorStrategy = "ignore"
     }
     withName:trimPrimerSequences {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_illumina:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "2 GB"
+        errorStrategy = "ignore"
     }
     withName:makeConsensus {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_illumina:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
-        memory = "2 GB"
+        memory = "4 GB"
+        errorStrategy = "ignore"
     }
     withName:callVariants {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_illumina:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
-        memory = "2 GB"
+        memory = "4 GB"
+        errorStrategy = "ignore"
     }
     withName:makeQCCSV {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_illumina:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "2 GB"
+        errorStrategy = "ignore"
     }
     withName:collateSamples {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_illumina:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "2 GB"
+        errorStrategy = "ignore"
     }
 }

--- a/covid-pipeline/ncov-nanopore-k8s.config
+++ b/covid-pipeline/ncov-nanopore-k8s.config
@@ -10,35 +10,42 @@ process {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_nanopore:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "500 MB"
+        errorStrategy = "ignore"
     }
     withName:articDownloadScheme {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_nanopore:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "500 MB"
+        errorStrategy = "ignore"
     }
     withName:articGuppyPlex {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_nanopore:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "2 GB"
+        errorStrategy = "ignore"
     }
     withName:articMinIONMedaka {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_nanopore:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
-        memory = "2 GB"
+        memory = "4 GB"
+        errorStrategy = "ignore"
     }
     withName:articRemoveUnmappedReads {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_nanopore:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "2 GB"
+        errorStrategy = "ignore"
     }
     withName:makeQCCSV {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_nanopore:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "2 GB"
+        errorStrategy = "ignore"
     }
     withName:collateSamples {
         container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_nanopore:${env.DOCKER_IMAGE_TAG}"
         cpus = "1"
         memory = "2 GB"
+        errorStrategy = "ignore"
     }
 }

--- a/covid-pipeline/nextflow.config
+++ b/covid-pipeline/nextflow.config
@@ -76,6 +76,11 @@ params {
     directory = env.COVID_PIPELINE_INPUT_PATH
 }
 
+/*
+The directive `errorStrategy` is set to `ignore` for ncov processes.
+This prevents that a failing sample compromises the whole batch.
+*/
+
 process {
     executor = 'k8s'
 
@@ -110,6 +115,7 @@ process {
             container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_illumina:${env.DOCKER_IMAGE_TAG}"
             cpus = "1"
             memory = "2 GB"
+            errorStrategy = "ignore"
         }
         if ( params.input_type == "fastq" ) {
             withName:append_metadata_match_to_sample_file_pair {
@@ -180,7 +186,8 @@ process {
         withName:ncov2019_artic_nf_pipeline_medaka {
             container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019_artic_nf_nanopore:${env.DOCKER_IMAGE_TAG}"
             cpus = "1"
-            memory = "8 GB"
+            memory = "4 GB"
+            errorStrategy = "ignore"
         }
         withName:append_qc_pass_match_to_nanopore_samples {
             container = "${env.DOCKER_IMAGE_PREFIX}/covid-pipeline:${env.DOCKER_IMAGE_TAG}"


### PR DESCRIPTION
Error strategy is set to ignore for ncov processes.
We will need a process to diagnose and if an expected file is missing, this will be stored in an `ncov-fail` directory. See: https://jira.congenica.net/browse/PSG-211 .

example, generated from nextflow:
```
Containers:
  nf-9415305e2f38b8f6da1ed1c116f04e35:
    Container ID:  
    Image:         144563655722.dkr.ecr.eu-west-1.amazonaws.com/congenica/dev/ncov2019_artic_nf_nanopore:1.0.0
    Image ID:      
    Port:          <none>
    Host Port:     <none>
    Command:
      /bin/bash
      -ue
      .command.run
    State:          Waiting
      Reason:       ContainerCreating
    Ready:          False
    Restart Count:  0
    Limits:
      cpu:     1
      memory:  4Gi
    Requests:
      cpu:        1
      memory:     4Gi
    Environment:  <none>
    Mounts:
      /data from vol-900 (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from covid-pipeline-admin-token-c4g2f (ro)
```