### PR TITLE
PSG-214: add pangolin scorpio and version columns

### DIFF
--- a/minikube/deploy_db.yaml
+++ b/minikube/deploy_db.yaml
@@ -42,7 +42,7 @@ spec:
         app: psql
     spec:
       containers:
-      - image: covid-pipeline-db:1.0.0
+      - image: 144563655722.dkr.ecr.eu-west-1.amazonaws.com/congenica/dev/covid-pipeline-db:1.0.0
         name: psql
         env:
         - name: POSTGRES_PASSWORD

--- a/scripts/db/models.py
+++ b/scripts/db/models.py
@@ -177,6 +177,32 @@ class Sample(Base):  # type: ignore
         server_default=FetchedValue(),
         comment="Reported pangolin lineage status",
     )
+    scorpio_call = Column(
+        String, comment="If a query is assigned a constellation by scorpio this call is output in this column"
+    )
+    scorpio_support = Column(
+        Float,
+        comment=(
+            "The support score is the proportion of defining variants which have the alternative "
+            "allele in the sequence.",
+        ),
+    )
+    scorpio_conflict = Column(
+        Float,
+        comment=(
+            "The conflict score is the proportion of defining variants which have the reference allele "
+            "in the sequence.",
+        ),
+    )
+    note = Column(
+        String,
+        comment=(
+            "If any conflicts from the decision tree, this field will output the alternative assignments. "
+            "If the sequence failed QC this field will describe why. If the sequence met the SNP thresholds "
+            "for scorpio to call a constellation, it’ll describe the exact SNP counts of Alt, Ref and Amb "
+            "(Alternative, reference and ambiguous) alleles for that call.",
+        ),
+    )
     genbank_submit_id = Column(
         String, comment="Unique identifier of GenBank submission " "session, which was used to submit a sample."
     )
@@ -217,7 +243,9 @@ class SampleQC(Base):  # type: ignore
     qc_pass = Column(Boolean, comment="Has sample passed QC")
     qc_plot = Column(LargeBinary, comment="QC plot image")
     pipeline_version = Column(String, comment="mapping pipeline version")
+    pangolin_version = Column(String, comment="pangolin version")
     pangolearn_version = Column(String, comment="pangoLEARN version used by Pangolin")
+    pango_version = Column(String, comment="pango version used by Pangolin")
 
 
 t_sample_comorbidity = Table(

--- a/scripts/load_pangolin_data_to_db.py
+++ b/scripts/load_pangolin_data_to_db.py
@@ -25,7 +25,15 @@ def load_data_from_csv(session: scoped_session, sample_name: str, sample_from_cs
     sample.pangolin_conflict = sample_from_csv["conflict"] if sample_from_csv["conflict"] else None
     sample.pangolin_ambiguity_score = sample_from_csv["ambiguity_score"] if sample_from_csv["ambiguity_score"] else None
     sample.pangolin_status = pangolin_status
+
+    sample.scorpio_call = sample_from_csv["scorpio_call"] if sample_from_csv["scorpio_call"] else None
+    sample.scorpio_support = sample_from_csv["scorpio_support"] if sample_from_csv["scorpio_support"] else None
+    sample.scorpio_conflict = sample_from_csv["scorpio_conflict"] if sample_from_csv["scorpio_conflict"] else None
+    sample.note = sample_from_csv["note"] if sample_from_csv["note"] else None
+
+    sample.sample_qc.pangolin_version = sample_from_csv["pangolin_version"]
     sample.sample_qc.pangolearn_version = sample_from_csv["pangoLEARN_version"]
+    sample.sample_qc.pango_version = sample_from_csv["pango_version"]
 
 
 @click.command()

--- a/sqitch/deploy/17-add_scorpio_fields.sql
+++ b/sqitch/deploy/17-add_scorpio_fields.sql
@@ -1,0 +1,23 @@
+-- add scorpio fields as calculated by pangolin
+-- requires: 02-apptables
+
+BEGIN;
+
+    SET LOCAL search_path = sars_cov_2;
+
+    ALTER TABLE "sample" ADD COLUMN IF NOT EXISTS "scorpio_call" VARCHAR;
+    ALTER TABLE "sample" ADD COLUMN IF NOT EXISTS "scorpio_support" DOUBLE PRECISION;
+    ALTER TABLE "sample" ADD COLUMN IF NOT EXISTS "scorpio_conflict" DOUBLE PRECISION;
+    ALTER TABLE "sample" ADD COLUMN IF NOT EXISTS "note" VARCHAR;
+
+    COMMENT ON COLUMN "sample"."scorpio_call"
+        IS 'If a query is assigned a constellation by scorpio this call is output in this column. The full set of constellations searched by default can be found at the constellations repository';
+    COMMENT ON COLUMN "sample"."scorpio_support"
+        IS 'The support score is the proportion of defining variants which have the alternative allele in the sequence.';
+    COMMENT ON COLUMN "sample"."scorpio_conflict"
+        IS 'The conflict score is the proportion of defining variants which have the reference allele in the sequence. Ambiguous/other non-ref/alt bases at each of the variant positions contribute only to the denominators of these scores';
+    COMMENT ON COLUMN "sample"."note"
+        IS 'If any conflicts from the decision tree, this field will output the alternative assignments. If the sequence failed QC this field will describe why. If the sequence met the SNP thresholds for scorpio to call a constellation, it’ll describe the exact SNP counts of Alt, Ref and Amb (Alternative, reference and ambiguous) alleles for that call';
+
+COMMIT;
+

--- a/sqitch/deploy/18-add_pango_versions.sql
+++ b/sqitch/deploy/18-add_pango_versions.sql
@@ -1,0 +1,15 @@
+-- Add pango versions to sample_qc table
+-- requires: 02-apptables
+
+BEGIN;
+
+    SET LOCAL search_path = sars_cov_2;
+
+    ALTER TABLE "sample_qc" ADD COLUMN IF NOT EXISTS "pangolin_version" VARCHAR;
+    ALTER TABLE "sample_qc" ADD COLUMN IF NOT EXISTS "pango_version" VARCHAR;
+
+    COMMENT ON COLUMN "sample_qc"."pangolin_version"
+        IS 'The version of Pangolin.';
+    COMMENT ON COLUMN "sample_qc"."pango_version"
+        IS 'The version of pango used by Pangolin.';
+COMMIT;

--- a/sqitch/revert/17-add_scorpio_fields.sql
+++ b/sqitch/revert/17-add_scorpio_fields.sql
@@ -1,0 +1,12 @@
+-- Revert covid-pipeline:17-add_scorpio_fields from pg
+
+BEGIN;
+
+    SET LOCAL search_path = sars_cov_2;
+
+    ALTER TABLE "sample" DROP COLUMN IF EXISTS "scorpio_call";
+    ALTER TABLE "sample" DROP COLUMN IF EXISTS "scorpio_support";
+    ALTER TABLE "sample" DROP COLUMN IF EXISTS "scorpio_conflict";
+    ALTER TABLE "sample" DROP COLUMN IF EXISTS "note";
+
+COMMIT;

--- a/sqitch/revert/18-add_pango_versions.sql
+++ b/sqitch/revert/18-add_pango_versions.sql
@@ -1,0 +1,10 @@
+-- Revert covid-pipeline:04-add-pangolearn-version from pg
+
+BEGIN;
+
+    SET LOCAL search_path = sars_cov_2;
+
+    ALTER TABLE "sample_qc" DROP COLUMN IF EXISTS "pangolin_version";
+    ALTER TABLE "sample_qc" DROP COLUMN IF EXISTS "pango_version";
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -15,3 +15,5 @@
 14-alter_sample_mrn_to_varchar [02-apptables] 2020-12-17T10:50:27Z Piero Dalle Pezze <piero.dallepezze@congenica.com> # Alter SAMPLE.MRN type from INTEGER to VARCHAR
 15-columns_to_lowercase [02-apptables] 2020-12-17T13:26:47Z Piero Dalle Pezze <piero.dallepezze@congenica.com> # Lowercase columns in sample_qc table
 16-update_pangolin_fields [02-apptables] 2021-12-02T14:56:13Z Piero Dalle Pezze <piero.dallepezze@congenica.com> # Add pangolin_conflict, pangolin_ambiguity_score columns to the sample table
+17-add_scorpio_fields [02-apptables] 2022-02-17T16:30:13Z Piero Dalle Pezze <piero.dallepezze@congenica.com> # Add scorpio fields as calculated by pangolin
+18-add_pango_versions [02-apptables] 2022-02-17T16:54:13Z Piero Dalle Pezze <piero.dallepezze@congenica.com> # Add pangolin and pango versions

--- a/sqitch/verify/17-add_scorpio_fields.sql
+++ b/sqitch/verify/17-add_scorpio_fields.sql
@@ -1,0 +1,41 @@
+-- Verify covid-pipeline:17-add_scorpio_fields on pg
+DO $$
+BEGIN
+
+    ASSERT (
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema='sars_cov_2' AND table_name='sample'
+            AND column_name='scorpio_call'
+        )
+    );
+
+    ASSERT (
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema='sars_cov_2' AND table_name='sample'
+            AND column_name='scorpio_support'
+        )
+    );
+
+    ASSERT (
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema='sars_cov_2' AND table_name='sample'
+            AND column_name='scorpio_conflict'
+        )
+    );
+
+    ASSERT (
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema='sars_cov_2' AND table_name='sample'
+            AND column_name='note'
+        )
+    );
+
+END $$;

--- a/sqitch/verify/18-add_pango_versions.sql
+++ b/sqitch/verify/18-add_pango_versions.sql
@@ -1,0 +1,24 @@
+-- Verify covid-pipeline:04-add-pangolearn-version on pg
+
+DO $$
+BEGIN
+
+    ASSERT (
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema='sars_cov_2' AND table_name='sample_qc'
+            AND column_name='pangolin_version'
+        )
+    );
+
+    ASSERT (
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema='sars_cov_2' AND table_name='sample_qc'
+            AND column_name='pango_version'
+        )
+    );
+
+END $$;


### PR DESCRIPTION
Add:
* 4 scorpio columns (call, support, conflict, note)
* 2 pangolin versions (pangolin, pango)


**TESTING**
running migrations
```
Deploying changes to db:pg:covid_pipeline_db
  + 01-appschema .................... ok
  + 02-apptables .................... ok
  + 04-add-pangolearn-version ....... ok
  + 05-governorates ................. ok
  + 06-areas ........................ ok
  + 07-remove_block_fk .............. ok
  + 08-add_area_colours ............. ok
  + 09-add_pangolin_pass ............ ok
  + 10-add_metadata_loaded_flag ..... ok
  + 13-add_genbank_submit_session ... ok
  + 14-alter_sample_mrn_to_varchar .. ok
  + 15-columns_to_lowercase ......... ok
  + 16-update_pangolin_fields ....... ok
  + 17-add_scorpio_fields ........... ok                            <===
  + 18-add_pango_versions ........... ok                         <===
```

pipeline execution
```
[74/b294f2] Submitted process > load_metadata
[71/450300] Submitted process > filter_input_files_matching_metadata:append_metadata_match_to_sample_file_pair (1)
[f3/440899] Submitted process > filter_input_files_matching_metadata:append_metadata_match_to_sample_file_pair (2)
[8f/2d9b54] Submitted process > filter_input_files_matching_metadata:append_metadata_match_to_sample_file_pair (3)
[60/99993a] Submitted process > filter_input_files_matching_metadata:append_match_to_current_session_samples (2)
[c7/99720f] Submitted process > filter_input_files_matching_metadata:append_match_to_current_session_samples (1)
[a5/c63c97] Submitted process > filter_input_files_matching_metadata:append_match_to_current_session_samples (3)
[d8/2ce36c] Submitted process > ncov2019_artic_nf_pipeline
[dc/e4b84e] Submitted process > reheader_genome_fasta (2)
[e5/86c192] Submitted process > reheader_genome_fasta (1)
[1d/9c294a] Submitted process > store_ncov_qc_plots
[7a/b942d1] Submitted process > store_ncov2019_artic_nf_output
[ce/29f76d] Submitted process > reheader_genome_fasta (3)
[e4/f6802b] Submitted process > load_ncov_assembly_qc_to_db
[43/2c99f8] Submitted process > store_reheadered_fasta_passed (1)
[26/5e70f1] Submitted process > store_reheadered_fasta_passed (2)
[4f/eda1fe] Submitted process > store_reheadered_fasta_passed (3)
[77/b2e923] Submitted process > pangolin_pipeline (1)
[4d/6ce723] Submitted process > pangolin_pipeline (2)
[63/69bbd5] Submitted process > pangolin_pipeline (3)
[db/9a0dfc] Submitted process > create_genbank_submission_files (1)
[90/2eb76a] Submitted process > store_genbank_submission (1)
[5a/971abf] Submitted process > load_pangolin_data_to_db (1)
[cc/34dd36] Submitted process > load_pangolin_data_to_db (2)
[19/00827f] Submitted process > load_pangolin_data_to_db (3)
[1e/75e41e] Submitted process > pipeline_complete (1)
[2d/061590] Submitted process > pipeline_complete (2)
[4c/ba36dc] Submitted process > pipeline_complete (3)
```


**DB**
```
covid_pipeline_db=# select * from sars_cov_2.sample;
 sample_id | lab_id  |   date_collected    | data_sequenced | sequencing_run | gender | age | nationality | governorate_name | area_name | block_number | sample_number | ct_val
ue |       symptoms        | travel_exposure | hospital_admittance | pangolin_lineage | gisaid_id | genome_length |    mrn    | pangolin_status | metadata_loaded | genbank_subm
it_id | pangolin_conflict | pangolin_ambiguity_score |      scorpio_call      | scorpio_support | scorpio_conflict |                                   note                     
               
-----------+---------+---------------------+----------------+----------------+--------+-----+-------------+------------------+-----------+--------------+---------------+-------
---+-----------------------+-----------------+---------------------+------------------+-----------+---------------+-----------+-----------------+-----------------+-------------
------+-------------------+--------------------------+------------------------+-----------------+------------------+------------------------------------------------------------
---------------
         2 | 7284954 | 2020-08-12 00:00:00 |                |                | U      |  35 | Bahraini    | Southern         | ISA TOWN  | 812          | 7284954       |       
34 | Headache, Sore Throat |                 |                     | AY.4             |           |               | 430501185 | passed_qc       | t               |             
      |                 0 |        0.936748329621381 | Delta (AY.4-like)      |          0.9375 |                0 | scorpio call: Alt alleles 30; Ref alleles 0; Amb alleles 2;
 Oth alleles 0
         1 | 7174693 | 2020-08-12 00:00:00 |                |                | U      |  25 | Bahraini    | Southern         | ISA TOWN  | 812          | 7174693       |       
34 | Headache, Sore Throat |                 |                     | AY.98            |           |               | 440501185 | passed_qc       | t               |             
      |                 0 |        0.915985467756585 | Delta (B.1.617.2-like) |               1 |                0 | scorpio call: Alt alleles 13; Ref alleles 0; Amb alleles 0;
 Oth alleles 0
         3 | 8039686 | 2020-08-12 00:00:00 |                |                | U      |  15 | Bahraini    | Southern         | ISA TOWN  | 812          | 8039686       |       
34 | Headache, Sore Throat |                 |                     | BA.1             |           |               | 420501185 | passed_qc       | t               |             
      |                 0 |        0.849361291877561 | Omicron (BA.1-like)    |          0.8448 |                0 | scorpio call: Alt alleles 49; Ref alleles 0; Amb alleles 7;
 Oth alleles 2
```

```
covid_pipeline_db=# select sample_id, pangolin_version, pangolearn_version, pango_version from sars_cov_2.sample_qc;
 sample_id | pangolin_version | pangolearn_version | pango_version 
-----------+------------------+--------------------+---------------
         2 | 3.1.17           | 2022-01-20         | v1.2.123
         1 | 3.1.17           | 2022-01-20         | v1.2.123
         3 | 3.1.17           | 2022-01-20         | v1.2.123
(3 rows)
```