### PR TITLE
PSG-273: fix reheader workflow. 

### DIFF
--- a/psga/common/check_metadata.nf
+++ b/psga/common/check_metadata.nf
@@ -2,6 +2,8 @@
  * Check the metadata in the database
  */
 process check_metadata {
+  tag "${metadata}"
+
   input:
     val load_missing_samples
     path metadata

--- a/psga/common/fastqc.nf
+++ b/psga/common/fastqc.nf
@@ -2,13 +2,13 @@
  * Run: fastqc
  */
 process fastqc {
-  tag "${task.index} - ${fastq_file}"
+  tag "${task.index} - ${ch_input_files}"
 
   input:
-    path fastq_file
+    path ch_input_files
 
   output:
-    path "fastqc.done", emit: ch_fastqc_done
+    path ch_input_files, emit: ch_input_files
     path "*_fastqc.html", emit: ch_fastqc_html_report
     path "*_fastqc.zip", emit: ch_fastqc_zip_report
 
@@ -18,8 +18,6 @@ process fastqc {
   for fq in `ls *.fastq*`; do
       fastqc ${fq}
   done
-
-  touch "fastqc.done"
   '''
 }
 

--- a/psga/common/genbank.nf
+++ b/psga/common/genbank.nf
@@ -148,30 +148,20 @@ process store_genbank_submission{
 workflow genbank_submission {
     take:
         ch_qc_passed_fastas
-        genbank_submission_template
-        genbank_submission_comment
-        genbank_submitter_name
-        genbank_submitter_account_namespace
-        genbank_submission_id_suffix
-        genbank_storage_remote_url
-        genbank_storage_remote_username
-        genbank_storage_remote_password
-        genbank_storage_remote_directory
-        analysis_run
     main:
 
         Channel
-            .fromPath( genbank_submission_template )
+            .fromPath( params.genbank_submission_template )
             .set{ ch_genbank_submission_template }
 
         create_genbank_submission_files(
             ch_qc_passed_fastas,
             ch_genbank_submission_template,
-            genbank_submission_comment,
-            genbank_submitter_name,
-            genbank_submitter_account_namespace,
-            genbank_submission_id_suffix,
-            analysis_run
+            params.genbank_submission_comment,
+            params.genbank_submitter_name,
+            params.genbank_submitter_account_namespace,
+            params.genbank_submission_id_suffix,
+            params.run
         )
 
         create_genbank_submission_files.out.ch_samples_txt
@@ -190,10 +180,10 @@ workflow genbank_submission {
             create_genbank_submission_files.out.ch_genbank_submission_id
         )
 
-        if ( genbank_storage_remote_url
-          && genbank_storage_remote_username
-          && genbank_storage_remote_password
-          && genbank_storage_remote_directory) {
+        if ( params.genbank_storage_remote_url
+          && params.genbank_storage_remote_username
+          && params.genbank_storage_remote_password
+          && params.genbank_storage_remote_directory) {
 
             submit_genbank_files(
                 create_genbank_submission_files.out.ch_genbank_xml,
@@ -201,17 +191,17 @@ workflow genbank_submission {
                 create_genbank_submission_files.out.ch_samples_txt,
                 create_genbank_submission_files.out.ch_genbank_submission_id,
                 ch_no_samples_flag.collect(),
-                genbank_storage_remote_url,
-                genbank_storage_remote_username,
-                genbank_storage_remote_password,
-                genbank_storage_remote_directory
+                params.genbank_storage_remote_url,
+                params.genbank_storage_remote_username,
+                params.genbank_storage_remote_password,
+                params.genbank_storage_remote_directory
             )
 
             mark_samples_as_submitted_to_genbank(
                 submit_genbank_files.out.ch_genbank_sample_names_txt,
                 ch_no_samples_flag.collect(),
                 submit_genbank_files.out.ch_genbank_submission_id,
-                analysis_run
+                params.run
             )
         }
         else {

--- a/psga/common/pipeline_lifespan.nf
+++ b/psga/common/pipeline_lifespan.nf
@@ -36,6 +36,6 @@ process pipeline_end {
   # use shell because we need a wildcard
   session_id_file="!{PSGA_INCOMPLETE_ANALYSIS_RUNS_PATH}/!{run}_!{workflow.sessionId}"
   # remove file and any attempts as no longer needed
-  rm ${session_id_file}*
+  rm -f ${session_id_file}*
   '''
 }

--- a/psga/main.nf
+++ b/psga/main.nf
@@ -158,15 +158,7 @@ workflow {
     )
 
     if ( params.pathogen == "sars_cov_2" ) {
-        psga_workflow = sars_cov_2(
-            fastqc.out.ch_fastqc_done,
-            ch_input_files,
-            params.run,
-            params.scheme_repo_url,
-            params.scheme_dir,
-            params.scheme,
-            params.scheme_version
-        )
+        psga_workflow = sars_cov_2(fastqc.out.ch_input_files)
     } else {
         log.error """\
             ERROR: Unsupported pathogen.
@@ -175,19 +167,7 @@ workflow {
         System.exit(1)
     }
 
-    genbank_submission(
-        psga_workflow.ch_qc_passed_fasta.collect(),
-        params.genbank_submission_template,
-        params.genbank_submission_comment,
-        params.genbank_submitter_name,
-        params.genbank_submitter_account_namespace,
-        params.genbank_submission_id_suffix,
-        params.genbank_storage_remote_url,
-        params.genbank_storage_remote_username,
-        params.genbank_storage_remote_password,
-        params.genbank_storage_remote_directory,
-        params.run
-    )
+    genbank_submission(psga_workflow.ch_qc_passed_fasta.collect())
 
     pipeline_end(
         params.run,

--- a/scripts/reheader_fasta.py
+++ b/scripts/reheader_fasta.py
@@ -54,12 +54,6 @@ def reheader_fasta(source: str, destination: str) -> None:
     """
     destination = destination or source
 
-    # ncov returns consensus *.fa files when executed with the illumina workflow, but
-    # it returns consensus *.fasta files when executed with the nanopore workflow
-    # Here we rename any *.fasta to *.fa as 'fasta' is the extension of our output files
-    for path in Path(source).rglob(f"*.consensus.{FASTA_FILE_HANDLE}"):
-        path.rename(path.with_suffix(f".{FASTA_FILE_EXTENSION}"))
-
     for path in Path(source).rglob(f"*.consensus.{FASTA_FILE_EXTENSION}"):
         click.echo(f"processing file {path}")
         convert_file(path, Path(destination))


### PR DESCRIPTION
In PSG-270, sample fasta reheadering was detached from the completion of ncov for all samples. However, a concurrency issue emerged because ncov output channels were not grouped together. As a consequence, when PSGA processed a sufficiently large batch of samples, it could happen that the reheadering process received as an input a QC CSV and a fasta from different samples, raising a mismatch error. With this commit, ncov output channel is a tuple, so the outputs are grouped together per sample. This change alone is not sufficient though. The other issue was in the reheadering workflow itself. In particular, the branch channel storing the information whether a sample passed QC or not, had to be match against the reheadered fasta of the same sample.


**Testing**
8 illumina fastq samples
```
root@psga-minikube-75694f4c76-qwwc8:/app/psga# nextflow run . --run ${TEST_NAME} --workflow illumina_artic --filetype fastq --metadata s3://synthetic-data-dev/UKHSA/piero-test-data/metadata_test.csv --load_missing_samples true 
N E X T F L O W  ~  version 21.10.6
Launching `./main.nf` [drunk_shirley] - revision: 8ab5c70ff2
WARN: Missing GenBank upload credentials. Upload to GenBank Submission Portal will be skipped.
                Please set the following parameters in nextflow.config:
                    - genbank_submitter_name
                    - genbank_submitter_account_namespace
                    - genbank_storage_remote_directory
                    - genbank_storage_remote_username
                    - genbank_storage_remote_password
            
[8c/5c1f57] Submitted process > pipeline_start
[37/32ad1a] Submitted process > check_metadata (metadata_test.csv)
[3c/a1c1a6] Submitted process > store_metadata_notification
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR7150135_1.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR7150154_1.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR5466043_1.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR7150243_1.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR7150384_1.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR7150151_1.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR7150135_2.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR7150154_2.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR5466043_2.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR7150243_2.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR5466041_1.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR7150141_1.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR7150151_2.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR5466041_2.fastq.gz
Staging foreign file: s3://synthetic-data-dev/UKHSA/validation_ci/illumina_artic_fastq/ERR7150141_2.fastq.gz
[00/659a3a] Submitted process > get_sample_files:stage_sample_file_pair (7 - [dac2280a-73bf-4e92-bfcb-dd18c7f5d8a1_1.fastq.gz, dac2280a-73bf-4e92-bfcb-dd18c7f5d8a1_2.fastq.gz])
[8f/b42a80] Submitted process > fastqc (1 - [dac2280a-73bf-4e92-bfcb-dd18c7f5d8a1_1.fastq.gz, dac2280a-73bf-4e92-bfcb-dd18c7f5d8a1_2.fastq.gz])
[09/50d5a3] Submitted process > get_sample_files:stage_sample_file_pair (8 - [02114fc8-a827-4f3e-9cc8-4e6ec6b5fb70_1.fastq.gz, 02114fc8-a827-4f3e-9cc8-4e6ec6b5fb70_2.fastq.gz])
[78/e52a62] Submitted process > fastqc (2 - [02114fc8-a827-4f3e-9cc8-4e6ec6b5fb70_1.fastq.gz, 02114fc8-a827-4f3e-9cc8-4e6ec6b5fb70_2.fastq.gz])
[7f/50c790] Submitted process > get_sample_files:stage_sample_file_pair (5 - [f717f7c9-efa5-4347-b44b-3d7b20c9a7ba_1.fastq.gz, f717f7c9-efa5-4347-b44b-3d7b20c9a7ba_2.fastq.gz])
[71/228ef7] Submitted process > fastqc (3 - [f717f7c9-efa5-4347-b44b-3d7b20c9a7ba_1.fastq.gz, f717f7c9-efa5-4347-b44b-3d7b20c9a7ba_2.fastq.gz])
[8e/3e382f] Submitted process > get_sample_files:stage_sample_file_pair (6 - [21ac81bf-61cd-48a8-a338-a2ecf83a270b_1.fastq.gz, 21ac81bf-61cd-48a8-a338-a2ecf83a270b_2.fastq.gz])
[c5/731a9c] Submitted process > fastqc (4 - [21ac81bf-61cd-48a8-a338-a2ecf83a270b_1.fastq.gz, 21ac81bf-61cd-48a8-a338-a2ecf83a270b_2.fastq.gz])
[1e/c1a5ad] Submitted process > get_sample_files:stage_sample_file_pair (4 - [0f5960d2-fc71-4b10-a6ff-f81dab81a1f2_1.fastq.gz, 0f5960d2-fc71-4b10-a6ff-f81dab81a1f2_2.fastq.gz])
[51/f876e0] Submitted process > fastqc (5 - [0f5960d2-fc71-4b10-a6ff-f81dab81a1f2_1.fastq.gz, 0f5960d2-fc71-4b10-a6ff-f81dab81a1f2_2.fastq.gz])
[17/5db4d7] Submitted process > get_sample_files:stage_sample_file_pair (3 - [e693f1cd-4440-452e-86e2-cec27da4e460_1.fastq.gz, e693f1cd-4440-452e-86e2-cec27da4e460_2.fastq.gz])
[4a/5426b1] Submitted process > get_sample_files:stage_sample_file_pair (1 - [28c39552-b9cf-4617-bcfc-18d2a63ef3e9_1.fastq.gz, 28c39552-b9cf-4617-bcfc-18d2a63ef3e9_2.fastq.gz])
[bf/5bcfc3] Submitted process > get_sample_files:stage_sample_file_pair (2 - [9b02db37-232a-4916-83a0-1a12857e5949_1.fastq.gz, 9b02db37-232a-4916-83a0-1a12857e5949_2.fastq.gz])
[42/cfcc95] Submitted process > fastqc (6 - [e693f1cd-4440-452e-86e2-cec27da4e460_1.fastq.gz, e693f1cd-4440-452e-86e2-cec27da4e460_2.fastq.gz])
[11/8d55eb] Submitted process > fastqc (7 - [28c39552-b9cf-4617-bcfc-18d2a63ef3e9_1.fastq.gz, 28c39552-b9cf-4617-bcfc-18d2a63ef3e9_2.fastq.gz])
[0c/b01fe3] Submitted process > fastqc (8 - [9b02db37-232a-4916-83a0-1a12857e5949_1.fastq.gz, 9b02db37-232a-4916-83a0-1a12857e5949_2.fastq.gz])
[59/8882e9] Submitted process > sars_cov_2:ncov2019_artic (1 - [dac2280a-73bf-4e92-bfcb-dd18c7f5d8a1_1.fastq.gz, dac2280a-73bf-4e92-bfcb-dd18c7f5d8a1_2.fastq.gz])
[6b/231aab] Submitted process > sars_cov_2:ncov2019_artic (2 - [02114fc8-a827-4f3e-9cc8-4e6ec6b5fb70_1.fastq.gz, 02114fc8-a827-4f3e-9cc8-4e6ec6b5fb70_2.fastq.gz])
[28/17ade9] Submitted process > sars_cov_2:ncov2019_artic (3 - [f717f7c9-efa5-4347-b44b-3d7b20c9a7ba_1.fastq.gz, f717f7c9-efa5-4347-b44b-3d7b20c9a7ba_2.fastq.gz])
[89/ea377f] Submitted process > sars_cov_2:ncov2019_artic (4 - [21ac81bf-61cd-48a8-a338-a2ecf83a270b_1.fastq.gz, 21ac81bf-61cd-48a8-a338-a2ecf83a270b_2.fastq.gz])
[e3/7abd64] Submitted process > sars_cov_2:ncov2019_artic (5 - [0f5960d2-fc71-4b10-a6ff-f81dab81a1f2_1.fastq.gz, 0f5960d2-fc71-4b10-a6ff-f81dab81a1f2_2.fastq.gz])
[e0/6a625f] Submitted process > sars_cov_2:ncov2019_artic (6 - [e693f1cd-4440-452e-86e2-cec27da4e460_1.fastq.gz, e693f1cd-4440-452e-86e2-cec27da4e460_2.fastq.gz])
[e7/b63202] Submitted process > sars_cov_2:ncov2019_artic (7 - [28c39552-b9cf-4617-bcfc-18d2a63ef3e9_1.fastq.gz, 28c39552-b9cf-4617-bcfc-18d2a63ef3e9_2.fastq.gz])
[fc/432139] Submitted process > sars_cov_2:ncov2019_artic (8 - [9b02db37-232a-4916-83a0-1a12857e5949_1.fastq.gz, 9b02db37-232a-4916-83a0-1a12857e5949_2.fastq.gz])
[1b/4dc69c] Submitted process > store_fastqc_reports
[95/6383d7] Submitted process > sars_cov_2:reheader:reheader_fasta (1 - [dac2280a-73bf-4e92-bfcb-dd18c7f5d8a1.qc.csv, dac2280a-73bf-4e92-bfcb-dd18c7f5d8a1.primertrimmed.consensus.fa])
[68/a5e76b] Submitted process > sars_cov_2:reheader:reheader_fasta (2 - [02114fc8-a827-4f3e-9cc8-4e6ec6b5fb70.qc.csv, 02114fc8-a827-4f3e-9cc8-4e6ec6b5fb70.primertrimmed.consensus.fa])
[52/887ed6] Submitted process > sars_cov_2:reheader:reheader_fasta (3 - [f717f7c9-efa5-4347-b44b-3d7b20c9a7ba.qc.csv, f717f7c9-efa5-4347-b44b-3d7b20c9a7ba.primertrimmed.consensus.fa])
[88/3f7abd] Submitted process > sars_cov_2:reheader:reheader_fasta (4 - [21ac81bf-61cd-48a8-a338-a2ecf83a270b.qc.csv, 21ac81bf-61cd-48a8-a338-a2ecf83a270b.primertrimmed.consensus.fa])
[05/bcbff2] Submitted process > sars_cov_2:reheader:store_ncov2019_artic_qc_passed_fasta (1 - dac2280a-73bf-4e92-bfcb-dd18c7f5d8a1.fasta)
[a9/9fd6f5] Submitted process > sars_cov_2:reheader:store_ncov2019_artic_qc_passed_fasta (2 - 02114fc8-a827-4f3e-9cc8-4e6ec6b5fb70.fasta)
[c3/de5ac8] Submitted process > sars_cov_2:reheader:store_ncov2019_artic_qc_passed_fasta (3 - f717f7c9-efa5-4347-b44b-3d7b20c9a7ba.fasta)
[7e/a6769f] Submitted process > sars_cov_2:reheader:store_ncov2019_artic_qc_passed_fasta (4 - 21ac81bf-61cd-48a8-a338-a2ecf83a270b.fasta)
[33/249a08] Submitted process > sars_cov_2:pangolin (1 - dac2280a-73bf-4e92-bfcb-dd18c7f5d8a1.fasta)
[78/23d9ea] Submitted process > sars_cov_2:pangolin (2 - 02114fc8-a827-4f3e-9cc8-4e6ec6b5fb70.fasta)
[44/30dc1b] Submitted process > sars_cov_2:pangolin (3 - f717f7c9-efa5-4347-b44b-3d7b20c9a7ba.fasta)
[a4/8cae55] Submitted process > sars_cov_2:reheader:reheader_fasta (5 - [0f5960d2-fc71-4b10-a6ff-f81dab81a1f2.qc.csv, 0f5960d2-fc71-4b10-a6ff-f81dab81a1f2.primertrimmed.consensus.fa])
[f0/8abf46] Submitted process > sars_cov_2:pangolin (4 - 21ac81bf-61cd-48a8-a338-a2ecf83a270b.fasta)
[84/96d5d9] Submitted process > sars_cov_2:reheader:store_ncov2019_artic_qc_passed_fasta (5 - 0f5960d2-fc71-4b10-a6ff-f81dab81a1f2.fasta)
[0f/65c7ba] Submitted process > sars_cov_2:pangolin (5 - 0f5960d2-fc71-4b10-a6ff-f81dab81a1f2.fasta)
[74/cc4797] Submitted process > sars_cov_2:reheader:reheader_fasta (6 - [e693f1cd-4440-452e-86e2-cec27da4e460.qc.csv, e693f1cd-4440-452e-86e2-cec27da4e460.primertrimmed.consensus.fa])
[68/a24074] Submitted process > sars_cov_2:reheader:store_ncov2019_artic_qc_passed_fasta (6 - e693f1cd-4440-452e-86e2-cec27da4e460.fasta)
[d5/341bdb] Submitted process > sars_cov_2:pangolin (6 - e693f1cd-4440-452e-86e2-cec27da4e460.fasta)
[ed/e4c8ec] Submitted process > sars_cov_2:reheader:reheader_fasta (7 - [28c39552-b9cf-4617-bcfc-18d2a63ef3e9.qc.csv, 28c39552-b9cf-4617-bcfc-18d2a63ef3e9.primertrimmed.consensus.fa])
[0d/32b01b] Submitted process > sars_cov_2:reheader:store_ncov2019_artic_qc_passed_fasta (7 - 28c39552-b9cf-4617-bcfc-18d2a63ef3e9.fasta)
[7f/3c6067] Submitted process > sars_cov_2:pangolin (7 - 28c39552-b9cf-4617-bcfc-18d2a63ef3e9.fasta)
[f7/c56815] Submitted process > sars_cov_2:reheader:reheader_fasta (8 - [9b02db37-232a-4916-83a0-1a12857e5949.qc.csv, 9b02db37-232a-4916-83a0-1a12857e5949.primertrimmed.consensus.fa])
[1f/38abb7] Submitted process > sars_cov_2:submit_analysis_run_results:merge_ncov2019_artic_qc_sample_files
[0e/9b909d] Submitted process > sars_cov_2:reheader:store_ncov2019_artic_qc_passed_fasta (8 - 9b02db37-232a-4916-83a0-1a12857e5949.fasta)
[c7/dfd8b7] Submitted process > sars_cov_2:submit_analysis_run_results:store_ncov2019_artic_output
[aa/359665] Submitted process > sars_cov_2:pangolin (8 - 9b02db37-232a-4916-83a0-1a12857e5949.fasta)
[ff/90af82] Submitted process > genbank_submission:create_genbank_submission_files (1)
[09/88f9af] Submitted process > genbank_submission:store_genbank_submission (1)
[8c/21e03b] Submitted process > sars_cov_2:submit_analysis_run_results:merge_pangolin_sample_files
[6c/a7c1ed] Submitted process > sars_cov_2:submit_analysis_run_results:store_pangolin_output
[b0/b58d57] Submitted process > sars_cov_2:submit_analysis_run_results:load_results_to_db
[a0/d68932] Submitted process > pipeline_end

```

2 ont fastq samples:
```
root@psga-minikube-75694f4c76-qwwc8:/app/psga# nextflow run . --run ${TEST_NAME} --workflow medaka_artic --filetype fastq --metadata s3://synthetic-data-dev/UKHSA/small_tests/${TEST_NAME}/metadata.csv --load_missing_samples true -resume
N E X T F L O W  ~  version 21.10.6
Launching `./main.nf` [jovial_stone] - revision: 8ab5c70ff2
WARN: Missing GenBank upload credentials. Upload to GenBank Submission Portal will be skipped.
                Please set the following parameters in nextflow.config:
                    - genbank_submitter_name
                    - genbank_submitter_account_namespace
                    - genbank_storage_remote_directory
                    - genbank_storage_remote_username
                    - genbank_storage_remote_password
            
[c9/8f521a] Cached process > pipeline_start
[95/6ec35f] Cached process > check_metadata (metadata.csv)
[27/e017d4] Cached process > store_metadata_notification
[42/4756c1] Cached process > get_sample_files:stage_sample_file (2 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[a4/6d19db] Cached process > fastqc (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[ae/a07c33] Cached process > sars_cov_2:ncov2019_artic (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[2c/91afe4] Cached process > sars_cov_2:reheader:reheader_fasta (1 - [b833399a-4d49-4d00-abdb-39d5086a5a0d.qc.csv, b833399a-4d49-4d00-abdb-39d5086a5a0d.consensus.fa])
[74/6f0959] Cached process > get_sample_files:stage_sample_file (1 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq)
[eb/2e9f9f] Cached process > fastqc (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq)
[64/a9a361] Cached process > store_fastqc_reports
[a3/4385c5] Cached process > sars_cov_2:ncov2019_artic (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq)
[29/bfeebb] Cached process > sars_cov_2:submit_analysis_run_results:merge_ncov2019_artic_qc_sample_files
[44/88d0b2] Cached process > sars_cov_2:reheader:reheader_fasta (2 - [2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.qc.csv, 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.consensus.fa])
[fa/6b3afc] Cached process > sars_cov_2:submit_analysis_run_results:store_ncov2019_artic_output
[f7/06f6ee] Submitted process > sars_cov_2:reheader:store_ncov2019_artic_qc_passed_fasta (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[a1/551171] Submitted process > sars_cov_2:reheader:store_ncov2019_artic_qc_passed_fasta (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fasta)
[ab/367b78] Submitted process > sars_cov_2:pangolin (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[0b/aa5db0] Submitted process > sars_cov_2:pangolin (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fasta)
[0a/1cdeaf] Submitted process > genbank_submission:create_genbank_submission_files (1)
[03/860193] Submitted process > genbank_submission:store_genbank_submission (1)
[fa/dc54c5] Submitted process > sars_cov_2:submit_analysis_run_results:merge_pangolin_sample_files
[d5/1a8075] Submitted process > sars_cov_2:submit_analysis_run_results:store_pangolin_output
[a9/8bdc43] Submitted process > sars_cov_2:submit_analysis_run_results:load_results_to_db
[ba/e17eda] Submitted process > pipeline_end
```