### PR TITLE
PSG-280: configure nextflow to use k8s jobs instead of pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ export NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG=1.0.0
 export NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG=1.0.0
 export PANGOLIN_DOCKER_IMAGE_TAG=1.0.0
 
+# add project submodules
+git submodule init
+git submodule update
+
+# update pangolin, ncov2019_artic_nf to their latest commits
+# If you run this command, you need to regenerate the base images for pangolin and ncov2019
+git submodule update --remote --merge
+
 # create base images
 docker build -t ${DOCKER_IMAGE_PREFIX}/psga-base:${PSGA_DOCKER_IMAGE_TAG_BASE} -f docker/Dockerfile.psga-base .
 docker build -t ${DOCKER_IMAGE_PREFIX}/ncov2019-artic-nf-illumina-base:${NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG_BASE} -f docker/Dockerfile.ncov2019-artic-nf-illumina-base .
@@ -84,14 +92,6 @@ docker build -t ${DOCKER_IMAGE_PREFIX}/pangolin-base:${PANGOLIN_DOCKER_IMAGE_TAG
 # build main images
 docker build -t ${DOCKER_IMAGE_PREFIX}/psga:${PSGA_DOCKER_IMAGE_TAG} -f docker/Dockerfile.psga .
 docker build -t ${DOCKER_IMAGE_PREFIX}/psga-db:${PSGA_DOCKER_IMAGE_TAG} -f docker/Dockerfile.postgres .
-
-# add project submodules
-git submodule init
-git submodule update
-
-# update pangolin, ncov2019_artic_nf to their latest commits
-# If you run this command, you need to regenerate the base images for pangolin and ncov2019
-git submodule update --remote --merge
 
 # build ncov docker images
 docker build -t ${DOCKER_IMAGE_PREFIX}/ncov2019-artic-nf-illumina:${NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG} -f docker/Dockerfile.ncov2019-artic-nf-illumina .

--- a/docker/Dockerfile.psga-base
+++ b/docker/Dockerfile.psga-base
@@ -6,8 +6,12 @@ RUN apt-get update \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
 
-# fetch a version of nextflow including the nf-amazon plugin
-RUN wget -qO- https://github.com/nextflow-io/nextflow/releases/download/v21.10.6/nextflow-21.10.6-all | bash && chmod +x nextflow && mv nextflow /usr/bin
+# fetch a version of nextflow including the nf-amazon plugin. Install the nf-amazon plugin once for all
+ENV NXF_VER="22.05.0-edge"
+RUN wget -qO- https://github.com/nextflow-io/nextflow/releases/download/v${NXF_VER}/nextflow-${NXF_VER}-all | bash \
+  && chmod +x nextflow \
+  && mv nextflow /usr/bin \
+  && nextflow plugins install nf-amazon
 
 # install fastqc
 ENV FASTQC_VERSION="0.11.9"

--- a/psga/nextflow.config
+++ b/psga/nextflow.config
@@ -89,6 +89,9 @@ executor {
 }
 
 k8s {
+   // use k8s jobs instead of pods. See: https://github.com/nextflow-io/nextflow/pull/2751
+   computeResourceType = 'Job'
+
    pullPolicy = "${env.K8S_PULL_POLICY}"
    serviceAccount = "${env.K8S_SERVICE_ACCOUNT}"
    storageClaimName = "${env.K8S_STORAGE_CLAIM_NAME}"


### PR DESCRIPTION
This is a small but important PR.

**Changes**
* replace `v22.04.3` with `v22.05.0-edge`. Release notes: https://github.com/nextflow-io/nextflow/releases . In particular, this version contains the commit: https://github.com/nextflow-io/nextflow/commit/c70eb12d1caac1ca3e1acb7c5b2a0adbfae18ebe which is needed by us for the reasons explained in https://jira.congenica.net/browse/PSG-280 .
* install nf-amazon plugin in the psga-base image so that the plugin won't be downloaded every time the pipeline runs
* build and push psga-base image

**Testing**
```
root@psga-minikube-75694f4c76-j5rxw:/app/psga# export TEST_NAME="illumina_fastq"
nextflow run . -c sars_cov_2.config --run ${TEST_NAME} --ncov_workflow illumina_artic --filetype fastq --metadata s3://synthetic-data-dev/UKHSA/small_tests/${TEST_NAME}/metadata.csv --load_missing_samples true
N E X T F L O W  ~  version 22.05.0-edge
Launching `./main.nf` [shrivelled_cuvier] DSL2 - revision: 8eff3efa9c
WARN: Missing GenBank upload credentials. Upload to GenBank Submission Portal will be skipped.
                Please set the following parameters in nextflow.config:
                    - genbank_submitter_name
                    - genbank_submitter_account_namespace
                    - genbank_storage_remote_directory
                    - genbank_storage_remote_username
                    - genbank_storage_remote_password
            
[e4/3dd3f9] Submitted process > psga:pipeline_start
[20/270999] Submitted process > psga:check_metadata (metadata.csv)
[a0/10ac02] Submitted process > psga:store_valid_samples_metadata_notification
[29/e6c7df] Submitted process > psga:store_invalid_samples_metadata_notification
[82/757357] Submitted process > psga:get_sample_files:stage_sample_file_pair (2 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fastq.gz, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fastq.gz])
[36/c1441f] Submitted process > psga:get_sample_files:stage_sample_file_pair (1 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[17/9f843a] Submitted process > psga:fastqc (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fastq.gz, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fastq.gz])
[74/367565] Submitted process > psga:fastqc (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[b9/de81fd] Submitted process > psga:ncov2019_artic (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fastq.gz, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fastq.gz])
[95/a8f3fc] Submitted process > psga:ncov2019_artic (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[79/b5e340] Submitted process > psga:store_fastqc_reports
[26/7ed16a] Submitted process > psga:reheader:reheader_fasta (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a.qc.csv, aff01b7c-8a0a-40bf-927a-0548add8ea5a.primertrimmed.consensus.fa])
[8f/52e242] Submitted process > psga:reheader:reheader_fasta (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1.qc.csv, 9729bce7-f0a9-4617-b6e0-6145307741d1.primertrimmed.consensus.fa])
[15/fe2a1f] Submitted process > psga:submit_analysis_run_results:merge_ncov2019_artic_qc_sample_files
[97/f4142e] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (1 - aff01b7c-8a0a-40bf-927a-0548add8ea5a.fasta)
[a2/e48d35] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (2 - 9729bce7-f0a9-4617-b6e0-6145307741d1.fasta)
[43/7bd04d] Submitted process > psga:submit_analysis_run_results:store_ncov2019_artic_output
[87/12591e] Submitted process > psga:submit_analysis_run_results:load_ncov_results_to_db
[20/8d7be3] Submitted process > psga:pangolin (1 - aff01b7c-8a0a-40bf-927a-0548add8ea5a.fasta)
[16/2c1eb0] Submitted process > psga:pangolin (2 - 9729bce7-f0a9-4617-b6e0-6145307741d1.fasta)
[3b/0ab26d] Submitted process > genbank_submission:create_genbank_submission_files (1)
[9d/d38a35] Submitted process > psga:submit_analysis_run_results:store_missing_ncov_qc_notification
[02/6878be] Submitted process > psga:submit_analysis_run_results:store_passed_ncov_qc_notification
[40/4b19ad] Submitted process > psga:submit_analysis_run_results:store_failed_ncov_qc_notification
[49/dfd79f] Submitted process > genbank_submission:store_genbank_submission (1)
[c0/a36c37] Submitted process > psga:submit_analysis_run_results:merge_pangolin_sample_files
[2e/1c745b] Submitted process > psga:submit_analysis_run_results:store_pangolin_output
[f9/72db45] Submitted process > psga:submit_analysis_run_results:load_pangolin_results_to_db
[86/a48383] Submitted process > psga:submit_analysis_run_results:store_failed_pangolin_notification
[7e/6d4ba0] Submitted process > psga:submit_analysis_run_results:store_unknown_pangolin_notification
[6f/63d14d] Submitted process > psga:submit_analysis_run_results:store_passed_pangolin_notification
[86/cb398f] Submitted process > psga:submit_analysis_run_results:results_submitted
[80/4e7406] Submitted process > pipeline_end


root@psga-minikube-75694f4c76-j5rxw:/app/psga# export TEST_NAME="illumina_bams"
nextflow run . -c sars_cov_2.config --run ${TEST_NAME} --ncov_workflow illumina_artic --filetype bam --metadata s3://synthetic-data-dev/UKHSA/small_tests/${TEST_NAME}/metadata.csv --load_missing_samples true
N E X T F L O W  ~  version 22.05.0-edge
Launching `./main.nf` [compassionate_coulomb] DSL2 - revision: 8eff3efa9c
WARN: Missing GenBank upload credentials. Upload to GenBank Submission Portal will be skipped.
                Please set the following parameters in nextflow.config:
                    - genbank_submitter_name
                    - genbank_submitter_account_namespace
                    - genbank_storage_remote_directory
                    - genbank_storage_remote_username
                    - genbank_storage_remote_password
            
[6e/200e26] Submitted process > psga:pipeline_start
[d1/57a7db] Submitted process > psga:check_metadata (metadata.csv)
[73/bca4bd] Submitted process > psga:store_invalid_samples_metadata_notification
[ff/e9a836] Submitted process > psga:store_valid_samples_metadata_notification
[e7/f57ea8] Submitted process > psga:get_sample_files:stage_sample_file (1 - 0c0b5622-d63a-42cc-a804-13d71e1a5306.bam)
[fc/e15d4d] Submitted process > psga:bam_to_fastq (1 - 0c0b5622-d63a-42cc-a804-13d71e1a5306.bam)
[6b/e3a366] Submitted process > psga:get_sample_files:stage_sample_file (2 - 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.bam)
[c4/5472e1] Submitted process > psga:bam_to_fastq (2 - 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.bam)
[6c/ef7d8a] Submitted process > psga:fastqc (1 - [0c0b5622-d63a-42cc-a804-13d71e1a5306_1.fastq.gz, 0c0b5622-d63a-42cc-a804-13d71e1a5306_2.fastq.gz])
[ff/4d673c] Submitted process > psga:fastqc (2 - [39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_1.fastq.gz, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_2.fastq.gz])
[91/331e82] Submitted process > psga:ncov2019_artic (1 - [0c0b5622-d63a-42cc-a804-13d71e1a5306_1.fastq.gz, 0c0b5622-d63a-42cc-a804-13d71e1a5306_2.fastq.gz])
[c0/0c549f] Submitted process > psga:ncov2019_artic (2 - [39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_1.fastq.gz, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_2.fastq.gz])
[b1/3c975c] Submitted process > psga:store_fastqc_reports
[04/3c3063] Submitted process > psga:reheader:reheader_fasta (1 - [0c0b5622-d63a-42cc-a804-13d71e1a5306.qc.csv, 0c0b5622-d63a-42cc-a804-13d71e1a5306.primertrimmed.consensus.fa])
[1f/64cbd1] Submitted process > psga:reheader:reheader_fasta (2 - [39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.qc.csv, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.primertrimmed.consensus.fa])
[8d/7acf4f] Submitted process > psga:submit_analysis_run_results:merge_ncov2019_artic_qc_sample_files
[82/ab8f3c] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (1 - 0c0b5622-d63a-42cc-a804-13d71e1a5306.fasta)
[15/269c72] Submitted process > psga:submit_analysis_run_results:store_ncov2019_artic_output
[a4/b66dd0] Submitted process > psga:submit_analysis_run_results:load_ncov_results_to_db
[21/c60e67] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (2 - 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.fasta)
[aa/dd4adc] Submitted process > psga:submit_analysis_run_results:store_missing_ncov_qc_notification
[f5/33f627] Submitted process > psga:submit_analysis_run_results:store_passed_ncov_qc_notification
[98/79e225] Submitted process > psga:submit_analysis_run_results:store_failed_ncov_qc_notification
[77/275bd5] Submitted process > psga:pangolin (1 - 0c0b5622-d63a-42cc-a804-13d71e1a5306.fasta)
[59/8cd66d] Submitted process > psga:pangolin (2 - 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.fasta)
[67/9cfb77] Submitted process > genbank_submission:create_genbank_submission_files (1)
[93/3bab99] Submitted process > genbank_submission:store_genbank_submission (1)
[3f/c0c749] Submitted process > psga:submit_analysis_run_results:merge_pangolin_sample_files
[c8/fe05db] Submitted process > psga:submit_analysis_run_results:store_pangolin_output
[54/b1efee] Submitted process > psga:submit_analysis_run_results:load_pangolin_results_to_db
[ed/dade44] Submitted process > psga:submit_analysis_run_results:store_passed_pangolin_notification
[32/a1bc6d] Submitted process > psga:submit_analysis_run_results:store_unknown_pangolin_notification
[42/e747ce] Submitted process > psga:submit_analysis_run_results:results_submitted
[52/514973] Submitted process > psga:submit_analysis_run_results:store_failed_pangolin_notification
[a8/4d7075] Submitted process > pipeline_end



root@psga-minikube-75694f4c76-j5rxw:/app/psga# export TEST_NAME="medaka_fastq"
root@psga-minikube-75694f4c76-j5rxw:/app/psga# nextflow run . -c sars_cov_2.config --run ${TEST_NAME} --ncov_workflow medaka_artic --filetype fastq --metadata s3://synthetic-data-dev/UKHSA/small_tests/${TEST_NAME}/metadata.csv --load_missing_samples true
N E X T F L O W  ~  version 22.05.0-edge
Launching `./main.nf` [scruffy_wright] DSL2 - revision: 8eff3efa9c
WARN: Missing GenBank upload credentials. Upload to GenBank Submission Portal will be skipped.
                Please set the following parameters in nextflow.config:
                    - genbank_submitter_name
                    - genbank_submitter_account_namespace
                    - genbank_storage_remote_directory
                    - genbank_storage_remote_username
                    - genbank_storage_remote_password
            
[47/a3bcc0] Submitted process > psga:pipeline_start
[99/9102ea] Submitted process > psga:check_metadata (metadata.csv)
[a3/a93c21] Submitted process > psga:store_invalid_samples_metadata_notification
[ea/5e3089] Submitted process > psga:store_valid_samples_metadata_notification
[a6/59d890] Submitted process > psga:get_sample_files:stage_sample_file (2 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[5a/f307a0] Submitted process > psga:get_sample_files:stage_sample_file (1 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq)
[5c/9165c4] Submitted process > psga:fastqc (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[e2/ea204d] Submitted process > psga:fastqc (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq)
[8d/75d68a] Submitted process > psga:ncov2019_artic (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[75/4eb38a] Submitted process > psga:ncov2019_artic (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq)
[50/bdb45c] Submitted process > psga:store_fastqc_reports
[55/33c9a6] Submitted process > psga:reheader:reheader_fasta (1 - [b833399a-4d49-4d00-abdb-39d5086a5a0d.qc.csv, b833399a-4d49-4d00-abdb-39d5086a5a0d.consensus.fa])
[22/79dab0] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[24/2c181f] Submitted process > psga:pangolin (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[45/5d9e0b] Submitted process > psga:reheader:reheader_fasta (2 - [2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.qc.csv, 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.consensus.fa])
[70/8ec710] Submitted process > psga:submit_analysis_run_results:merge_ncov2019_artic_qc_sample_files
[b5/ccd2df] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fasta)
[ad/3e3565] Submitted process > psga:submit_analysis_run_results:store_ncov2019_artic_output
[2c/bbd078] Submitted process > psga:submit_analysis_run_results:load_ncov_results_to_db
[d4/717dfd] Submitted process > psga:pangolin (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fasta)
[b6/70d206] Submitted process > genbank_submission:create_genbank_submission_files (1)
[e9/a219d7] Submitted process > psga:submit_analysis_run_results:store_failed_ncov_qc_notification
[45/0b7cd1] Submitted process > psga:submit_analysis_run_results:store_passed_ncov_qc_notification
[c9/1a3306] Submitted process > psga:submit_analysis_run_results:store_missing_ncov_qc_notification
[18/8d7d6c] Submitted process > genbank_submission:store_genbank_submission (1)
[23/c2a1f3] Submitted process > psga:submit_analysis_run_results:merge_pangolin_sample_files
[79/00a976] Submitted process > psga:submit_analysis_run_results:store_pangolin_output
[1a/396668] Submitted process > psga:submit_analysis_run_results:load_pangolin_results_to_db
[48/c218d9] Submitted process > psga:submit_analysis_run_results:store_failed_pangolin_notification
[53/ca7711] Submitted process > psga:submit_analysis_run_results:store_passed_pangolin_notification
[4a/66db38] Submitted process > psga:submit_analysis_run_results:store_unknown_pangolin_notification
[67/e17e59] Submitted process > psga:submit_analysis_run_results:results_submitted
[13/87cc26] Submitted process > pipeline_end



root@psga-minikube-75694f4c76-j5rxw:/app/psga# export TEST_NAME="no_ncov_fasta"
nextflow run . -c sars_cov_2.config --run ${TEST_NAME} --ncov_workflow no_ncov --filetype fasta --metadata s3://synthetic-data-dev/UKHSA/small_tests/${TEST_NAME}/metadata.csv --load_missing_samples true
N E X T F L O W  ~  version 22.05.0-edge
Launching `./main.nf` [mighty_tesla] DSL2 - revision: 8eff3efa9c
WARN: Missing GenBank upload credentials. Upload to GenBank Submission Portal will be skipped.
                Please set the following parameters in nextflow.config:
                    - genbank_submitter_name
                    - genbank_submitter_account_namespace
                    - genbank_storage_remote_directory
                    - genbank_storage_remote_username
                    - genbank_storage_remote_password
            
[1f/bad7cc] Submitted process > psga:pipeline_start
[18/771585] Submitted process > psga:check_metadata (metadata.csv)
[cd/a1cced] Submitted process > psga:store_valid_samples_metadata_notification
[e2/9e1521] Submitted process > psga:store_invalid_samples_metadata_notification
[b5/ef0070] Submitted process > psga:get_sample_files:stage_sample_file (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[fa/7604f7] Submitted process > psga:reheader:standardise_fasta (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[c9/d2fd7b] Submitted process > psga:reheader:reheader_fasta (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.consensus.fa)
[3e/15226f] Submitted process > psga:get_sample_files:stage_sample_file (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fasta)
[fc/df0eb1] Submitted process > psga:reheader:standardise_fasta (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fasta)
[06/6cd569] Submitted process > psga:reheader:reheader_fasta (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.consensus.fa)
[66/475c93] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[51/d67825] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fasta)
[23/68e419] Submitted process > psga:pangolin (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[a2/a50642] Submitted process > psga:pangolin (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fasta)
[b3/3ea59c] Submitted process > genbank_submission:create_genbank_submission_files (1)
[7d/82cce4] Submitted process > genbank_submission:store_genbank_submission (1)
[26/f36c92] Submitted process > psga:submit_analysis_run_results:merge_pangolin_sample_files
[5c/314ba8] Submitted process > psga:submit_analysis_run_results:store_pangolin_output
[63/e391f2] Submitted process > psga:submit_analysis_run_results:load_pangolin_results_to_db
[c4/cd40a4] Submitted process > psga:submit_analysis_run_results:store_passed_pangolin_notification
[3d/e0fb7f] Submitted process > psga:submit_analysis_run_results:results_submitted
[6e/91fbff] Submitted process > psga:submit_analysis_run_results:store_unknown_pangolin_notification
[5d/40fe94] Submitted process > psga:submit_analysis_run_results:store_failed_pangolin_notification
[b4/b50225] Submitted process > pipeline_end
```