### PR TITLE
PSG-280: increase psga-base tag version

### DIFF
--- a/docker/Dockerfile.psga
+++ b/docker/Dockerfile.psga
@@ -1,4 +1,4 @@
-FROM 144563655722.dkr.ecr.eu-west-1.amazonaws.com/congenica/dev/psga-base:1.0.0
+FROM 144563655722.dkr.ecr.eu-west-1.amazonaws.com/congenica/dev/psga-base:1.0.1
 
 # pin the versions of pip and poetry
 ENV PIP_VERSION=22.0.4 \


### PR DESCRIPTION
Increase psga-base image tag to force circle ci to use this base image without affecting the layer cache policy