### PR TITLE
PSG-374: remove field `note` from pangolin validation 

### DIFF
--- a/jenkins/config.py
+++ b/jenkins/config.py
@@ -21,7 +21,6 @@ data_config = {
                 "is_designated",
                 "qc_status",
                 "qc_notes",
-                "note",
             ],
             # abs tolerances for the columns to round
             "columns_to_round": {


### PR DESCRIPTION
as this is updated frequently and does not contain relevant information we need to validate (e.g. lineages)