### PR TITLE
PSG-407: apply error strategy to all processes returning a non-zero exit status.

### DIFF
--- a/psga/common/help.nf
+++ b/psga/common/help.nf
@@ -53,7 +53,7 @@ def printMainHelp() {
         K8S_QUEUE_SIZE          The maximum number of processes to run at the same time (default: 20)
         K8S_STORAGE_CLAIM_NAME  The Kubernetes PVC claim
         K8S_STORAGE_MOUNT_PATH  The Kubernetes mount path (default: /data)
-        K8S_PROCESS_MAX_RETRIES The maximum number that a process can be retried if a resource-based exit code (137-143) is raised (default: 3)
+        K8S_PROCESS_MAX_RETRIES The maximum number that a process can be retried if a non-zero exit status is returned (default: 3)
         K8S_PROCESS_CPU_LOW     Value for a process using little CPU. There is no need to change this as the pipeline was designed for high scalability (default: 1)
         K8S_PROCESS_CPU_HIGH    Value for a process using a lot of CPU. There is no need to change this as the pipeline was designed for high scalability (default: 2)
         K8S_PROCESS_MEMORY_VERY_LOW

--- a/psga/nextflow.config
+++ b/psga/nextflow.config
@@ -82,7 +82,9 @@ process {
     cpus = "${env.K8S_PROCESS_CPU_LOW}"
     memory = { "${env.K8S_PROCESS_MEMORY_LOW}" as int * 1.MB * task.attempt }
     maxRetries = "${env.K8S_PROCESS_MAX_RETRIES}"
-    errorStrategy = { (task.exitStatus in 137..143 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'terminate' }
+    // by default, re-run a process if exit status is not 0 for max retries.
+    // if the process still fails, terminate the pipeline
+    errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'terminate' }
 
     // The scratch directive allows you to execute the process in a temporary folder that is local to the execution node.
     // This is useful when your pipeline is launched by using a grid executor, because it allows you to decrease the NFS

--- a/psga/sars_cov_2.config
+++ b/psga/sars_cov_2.config
@@ -36,14 +36,12 @@ params {
 
 process {
 
-    // default directives. These can be fine-tuned per process
-    // use the local executor by default, so that the filtering-processes (which are only used for organising files) and any
-    // dummy processes (e.g. pipeline complete) are executed in the same container where the main pipeline runs.
-    executor = 'local'
-    cpus = "${env.K8S_PROCESS_CPU_LOW}"
-    memory = { "${env.K8S_PROCESS_MEMORY_LOW}" as int * 1.MB * task.attempt }
-    maxRetries = "${env.K8S_PROCESS_MAX_RETRIES}"
-    errorStrategy = { (task.exitStatus in 137..143 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'terminate' }
+    // NOTE: processes that are not listed below, are executed in the container where the main pipeline runs
+    // (executor=local by default).
+    // This should be done for dummy processes (e.g. pipeline_complete) only
+
+    // For processes running samples in parallel, ignore on repeated failure,
+    // so that the failure of a sample does not affect the analysis run
 
     withName:check_metadata {
         executor = 'k8s'
@@ -53,6 +51,7 @@ process {
     withName:fastqc {
         executor = 'k8s'
         container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.PSGA_PIPELINE_DOCKER_IMAGE_TAG}"
+        errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
     }
 
     if ( params.ncov_workflow == "illumina_artic" ) {
@@ -61,12 +60,14 @@ process {
                 executor = 'k8s'
                 container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019-artic-nf-illumina:${env.NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG}"
                 memory = { "${env.K8S_PROCESS_MEMORY_HIGH}" as int * 1.MB * task.attempt }
+                errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
             }
         }
 
         withName:contamination_removal_illumina {
             executor = 'k8s'
             container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.PSGA_PIPELINE_DOCKER_IMAGE_TAG}"
+            errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
         }
 
         // use more memory as this process runs a nextflow pipeline (Java)
@@ -77,12 +78,13 @@ process {
             // trimgalore requires 2 CPUS
             cpus = "${env.K8S_PROCESS_CPU_HIGH}"
             // if ncov sample dies, carry on with the other ncov samples
-            errorStrategy = { (task.exitStatus in 137..143 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
+            errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
         }
     } else if ( params.ncov_workflow == "medaka_artic" ) {
         withName:contamination_removal_ont {
             executor = 'k8s'
             container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.PSGA_PIPELINE_DOCKER_IMAGE_TAG}"
+            errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
         }
 
         // use more memory as this process runs a nextflow pipeline (Java)
@@ -91,7 +93,7 @@ process {
             container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019-artic-nf-nanopore:${env.NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG}"
             memory = { "${env.K8S_PROCESS_MEMORY_VERY_HIGH}" as int * 1.MB * task.attempt }
             // if the computation for 1 sample dies, do not interrupt the computation for the other samples
-            errorStrategy = { (task.exitStatus in 137..143 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
+            errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
         }
     }
 
@@ -99,6 +101,7 @@ process {
         executor = 'k8s'
         container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.PSGA_PIPELINE_DOCKER_IMAGE_TAG}"
         memory = { "${env.K8S_PROCESS_MEMORY_MEDIUM}" as int * 1.MB * task.attempt }
+        errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
     }
 
     withName:store_reheadered_qc_passed_fasta {
@@ -116,7 +119,7 @@ process {
         container = "${env.DOCKER_IMAGE_PREFIX}/pangolin:${env.PANGOLIN_DOCKER_IMAGE_TAG}"
         memory = { "${env.K8S_PROCESS_MEMORY_HIGH}" as int * 1.MB * task.attempt }
         // if the computation for 1 sample dies, do not interrupt the computation for the other samples
-        errorStrategy = { (task.exitStatus in 137..143 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
+        errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
     }
 
     withName:submit_ncov_results {


### PR DESCRIPTION
**Changes:**
- retry failing processes independently of their exit status
- ignore repeatedly failing processes running single samples

**Passing tests:**
https://jenkins.services.congenica.net/job/psga-pipeline-sars-cov-2-small-tests/job/PSG-407_retry_failing_job_for_any_non_zero_exit_code/

**Failing test:** 
I intentionally added an `exit 1` to the code of the first process to simulate the retry strategy.
Before, this would have terminated immediately, but not now.
```
root@psga-pipeline-minikube-85bddcff78-2t6w9:/app/psga# nextflow run . -c sars_cov_2.config --run illumina_artic_fastq_short --ncov_workflow illumina_artic --filetype fastq --metadata s3://synthetic-data-dev/UKHSA/small_tests/illumina_fastq/metadata.csv
N E X T F L O W  ~  version 22.05.0-edge
Launching `./main.nf` [scruffy_noether] DSL2 - revision: 44167a4de5
[f6/2331d6] Submitted process > psga:pipeline_start
[f6/2331d6] NOTE: Process `psga:pipeline_start` terminated with an error exit status (1) -- Execution is retried (1)
[4a/35e7b3] Re-submitted process > psga:pipeline_start
[4a/35e7b3] NOTE: Process `psga:pipeline_start` terminated with an error exit status (1) -- Execution is retried (2)
[d8/587d59] Re-submitted process > psga:pipeline_start
[d8/587d59] NOTE: Process `psga:pipeline_start` terminated with an error exit status (1) -- Execution is retried (3)
[e1/2c0a96] Re-submitted process > psga:pipeline_start
Error executing process > 'psga:pipeline_start'

Caused by:
  Process `psga:pipeline_start` terminated with an error exit status (1)

Command executed:

  # save the command so that we can resume it using autoresumer.py, if needed
  echo "#!/bin/bash" > /data/incomplete_analysis_runs/illumina_artic_fastq_short_3e7a2306-e9a1-4429-ad52-1f5043e0d433
  echo "export PSGA_OUTPUT_PATH=/data/output/illumina_artic_fastq_short" >> /data/incomplete_analysis_runs/illumina_artic_fastq_short_3e7a2306-e9a1-4429-ad52-1f5043e0d433
  echo "nextflow run /app/psga -c /app/psga/sars_cov_2.config --run illumina_artic_fastq_short --ncov_workflow illumina_artic --filetype fastq --metadata s3://synthetic-data-dev/UKHSA/small_tests/illumina_fastq/metadata.csv --scheme_repo_url /artic-network/primer-schemes --scheme_dir primer-schemes --scheme nCoV-2019 --scheme_version V3 -resume \$1" >> /data/incomplete_analysis_runs/illumina_artic_fastq_short_3e7a2306-e9a1-4429-ad52-1f5043e0d433
  
  exit 1

Command exit status:
  1

Command output:
  (empty)

Work dir:
  /data/work/e1/2c0a969f685b7d18a04c2d29460c23

Tip: you can try to figure out what's wrong by changing to the process work dir and showing the script file named `.command.sh`


              ERROR: No file was found for samples in metadata.
                Aborting!
```