### PR TITLE
PSG-403: inherit from k8s-agent

### DIFF
--- a/jenkins/files/sars_cov_2/Jenkinsfile
+++ b/jenkins/files/sars_cov_2/Jenkinsfile
@@ -82,6 +82,7 @@ pipeline {
         kubernetes {
             cloud params.CLUSTER_NAME
             namespace params.NAMESPACE
+            inheritFrom 'k8s-agent'
             yaml """
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
See: https://github.com/Congenica/api-testing/pull/122/files. 
Reason: stabilise the master pod.