### PR TITLE
Revert "PSG-403: inherit from k8s-agent"

### DIFF
--- a/jenkins/files/sars_cov_2/Jenkinsfile
+++ b/jenkins/files/sars_cov_2/Jenkinsfile
@@ -82,7 +82,6 @@ pipeline {
         kubernetes {
             cloud params.CLUSTER_NAME
             namespace params.NAMESPACE
-            inheritFrom 'k8s-agent'
             yaml """
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
Reverts Congenica/psga-pipeline#90

Interesting! Jenkins does not seem to override the serviceAccountName:
```
15:51:44    serviceAccount: "psga-admin"
15:51:44    serviceAccountName: "default"
```
it should not be default
```
        kubernetes {
            cloud params.CLUSTER_NAME
            namespace params.NAMESPACE
            inheritFrom 'k8s-agent'
            yaml """
apiVersion: v1
kind: Pod
spec:
  serviceAccount: ${params.NAMESPACE}-admin
  serviceAccountName: ${params.NAMESPACE}-admin      <<<<=====
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: ${params.K8S_NODE}
            operator: In
            values:
            - "true"
  containers:
  - name: psga
```