### PR TITLE
PSG-481: enable ncov configuration of primer

### DIFF
--- a/jenkins/files/sars_cov_2/Jenkinsfile
+++ b/jenkins/files/sars_cov_2/Jenkinsfile
@@ -15,16 +15,18 @@ Constructs build summary messages intended to be posted in Slack
 */
 def buildSlackMessage() {
     return """
-branch:           ${env.BRANCH_NAME}
-namespace:        ${params.NAMESPACE}
-metadata:         ${params.METADATA}
-psga_output_path: ${params.PSGA_OUTPUT_PATH}
-workdir:          ${params.NXF_WORK}
-run:              ${params.ANALYSIS_RUN}
-pathogen:         sars_cov_2
-workflow:         ${params.NCOV_WORKFLOW}
-filetype:         ${params.FILETYPE}
-started by:       ${getTriggerDescription()}
+branch:             ${env.BRANCH_NAME}
+namespace:          ${params.NAMESPACE}
+metadata:           ${params.METADATA}
+psga_output_path:   ${params.PSGA_OUTPUT_PATH}
+workdir:            ${params.NXF_WORK}
+run:                ${params.ANALYSIS_RUN}
+pathogen:           sars_cov_2
+workflow:           ${params.NCOV_WORKFLOW}
+filetype:           ${params.FILETYPE}
+primer scheme:      ${params.PRIMER_SCHEME}
+primer scheme_ver:  ${params.PRIMER_SCHEME_VERSION}
+started by:         ${getTriggerDescription()}
 """
 }
 
@@ -56,6 +58,8 @@ pipeline {
         string(name: 'ANALYSIS_RUN', defaultValue: 'illumina_artic_fastq_short', description: 'This can be the test name')
         choice(name: 'NCOV_WORKFLOW', choices: ['illumina_artic', 'medaka_artic', 'no_ncov'], description: 'The ncov workflow to run')
         choice(name: 'FILETYPE', choices: ['fastq', 'bam', 'fasta'], description: 'The input file type. illumina_artic supports fastq, bam; medaka_artic supports fastq; no_ncov supports fasta')
+        string(name: 'PRIMER_SCHEME', defaultValue: 'nCoV-2019', description: 'The name of the primer scheme used by the ncov-artic pipeline')
+        string(name: 'PRIMER_SCHEME_VERSION', defaultValue: 'V3', description: 'The version of the primer scheme used by the ncov-artic pipeline')
 
         string(name: 'CLUSTER_NAME', defaultValue: 'saas-dev.k8s.congenica.net', description: 'The Kubernetes cluster where the Congenica platform is deployed that the tests will run against.')
         string(name: 'NAMESPACE', defaultValue: 'psga', description: 'The Kubernetes namespace where the Congenica platform is deployed that the tests will run against.')
@@ -142,9 +146,11 @@ spec:
         PSGA_OUTPUT_PATH                            = "${params.PSGA_OUTPUT_PATH}"
 
         ANALYSIS_RUN                                = "${params.ANALYSIS_RUN}"
+        METADATA                                    = "${params.METADATA}"
         NCOV_WORKFLOW                               = "${params.NCOV_WORKFLOW}"
         FILETYPE                                    = "${params.FILETYPE}"
-        METADATA                                    = "${params.METADATA}"
+        PRIMER_SCHEME                               = "${params.PRIMER_SCHEME}"
+        PRIMER_SCHEME_VERSION                       = "${params.PRIMER_SCHEME_VERSION}"
 
         // other configs
         K8S_NODE                                    = "${params.K8S_NODE}"
@@ -190,7 +196,7 @@ spec:
 
                     // run the pipeline
                     // the argument `--load_missing_samples true` enables us to integration test the pipeline in isolation
-                    sh 'nextflow -log ${ANALYSIS_RUN}.log run ${PSGA_ROOT_PATH}/psga/main.nf -c ${PSGA_ROOT_PATH}/psga/sars_cov_2.config --run ${ANALYSIS_RUN} --ncov_workflow ${NCOV_WORKFLOW} --filetype ${FILETYPE} --metadata ${METADATA} -with-trace'
+                    sh 'nextflow -log ${ANALYSIS_RUN}.log run ${PSGA_ROOT_PATH}/psga/main.nf -c ${PSGA_ROOT_PATH}/psga/sars_cov_2.config --run ${ANALYSIS_RUN} --ncov_workflow ${NCOV_WORKFLOW} --filetype ${FILETYPE} --scheme ${PRIMER_SCHEME} --scheme_version ${PRIMER_SCHEME_VERSION} --metadata ${METADATA} -with-trace'
 
                     if (params.VALIDATION_TEST) {
                         // run validations


### PR DESCRIPTION
**Change:**
Enable ncov configuration of primer scheme and primer scheme version in our PSGA pipeline from Jenkins.


**Testing**
This shows that the scheme and version are passed over: 

Command:
```
nextflow run . -c sars_cov_2.config --run illumina_artic_fastq_short --ncov_workflow illumina_artic --filetype fastq --metadata s3://synthetic-data-dev/UKHSA/small_tests/illumina_fastq/metadata.csv --scheme_version V4
```
By default, the version is **V3**.
In the ncov workdir, we can see that the ncov pipeline was configured with the V4 version as passed to the pipeline.
```
root@psga-pipeline-minikube-85bddcff78-2t6w9:/data/work/50/cf6fb94e47d15e18ba00d01c762f2d# cat .command.sh 
#!/bin/bash -ue
ncov_out_dir="ncov_output"
ncov_fasta_out_dir="${ncov_out_dir}/ncovIllumina_sequenceAnalysis_makeConsensus"
ncov_qc_plots_dir="${ncov_out_dir}/qc_plots"
output_fasta="output_fasta"
output_plots="output_plots"

# convert nextflow variables to Bash so that the same format is used
ncov_prefix=illumina_artic_fastq_short
scheme_repo_url=/artic-network/primer-schemes
scheme_dir=primer-schemes
scheme=nCoV-2019
scheme_version=V4

# note: we inject our configuration into ncov to override parameters
# note: `pwd` is the workdir for this nextflow process
# note: use /tmp as work dir, so that the intermediate files for this pipeline remain local
#       instead of being shared with our pipeline
nextflow run ${PSGA_ROOT_PATH}/ncov2019-artic-nf       --illumina       --prefix ${ncov_prefix}       --directory `eval pwd`       --outdir ${ncov_out_dir}       --schemeRepoURL ${scheme_repo_url}       --schemeDir ${scheme_dir}       --scheme ${scheme}       --schemeVersion ${scheme_version}       -work-dir /tmp       -c ${PSGA_ROOT_PATH}/psga/sars_cov_2/ncov-illumina.config

mkdir -p ${output_fasta}
mkdir -p ${output_plots}
mv ${ncov_fasta_out_dir}/*.fa ${output_fasta}
mv ${ncov_qc_plots_dir}/*.png ${output_plots}

# extract the sample name from one of the reads and rename the qc csv
sample_name="$(ls *.gz | head -n 1 | cut -d"_" -f1)"
mv ${ncov_out_dir}/${ncov_prefix}.qc.csv ${ncov_out_dir}/${sample_name}.qc.csv
```