### PR TITLE
DO NOT MERGE: PSG-434: Create a dummy pathogen pipeline as a proof-of-concept

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG_BASE=1.0.0
 NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG_BASE=1.0.0
 PANGOLIN_DOCKER_IMAGE_TAG_BASE=1.0.0
 SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG=1.0.0
+DUMMY_PATHOGEN_PIPELINE_DOCKER_IMAGE_TAG=1.0.0
 NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG=1.0.0
 NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG=1.0.0
 PANGOLIN_DOCKER_IMAGE_TAG=1.0.0
@@ -32,3 +33,6 @@ sars-cov-2-images:
 	docker build -t ${DOCKER_IMAGE_PREFIX}/ncov2019-artic-nf-illumina:${NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG} -f docker/Dockerfile.ncov2019-artic-nf-illumina .
 	docker build -t ${DOCKER_IMAGE_PREFIX}/ncov2019-artic-nf-nanopore:${NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG} -f docker/Dockerfile.ncov2019-artic-nf-nanopore .
 	docker build -t ${DOCKER_IMAGE_PREFIX}/pangolin:${PANGOLIN_DOCKER_IMAGE_TAG} -f docker/Dockerfile.pangolin .
+
+dummy-pathogen-images:
+	docker build --build-arg pathogen=dummy_pathogen -t ${DOCKER_IMAGE_PREFIX}/dummy-pathogen-pipeline:${DUMMY_PATHOGEN_PIPELINE_DOCKER_IMAGE_TAG} -f docker/Dockerfile.psga-pipeline .

--- a/minikube/cleanup.sh
+++ b/minikube/cleanup.sh
@@ -5,6 +5,7 @@ kubectl get pods -n psga-minikube --no-headers=true | awk '/nf/{print $1}'| xarg
 
 ## delete psga-minikube
 kubectl delete deployment sars-cov-2-pipeline-minikube
+kubectl delete deployment dummy-pathogen-pipeline-minikube
 kubectl delete pvc psga-minikube-pvc
 kubectl delete rolebinding psga-minikube-admin
 kubectl delete serviceaccount psga-minikube-admin

--- a/minikube/deploy_dummy_pathogen.yaml
+++ b/minikube/deploy_dummy_pathogen.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dummy-pathogen-pipeline-minikube
+spec:
+  selector:
+    matchLabels:
+      app: dummy-pathogen-pipeline-minikube
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: dummy-pathogen-pipeline-minikube
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: farmNode
+                operator: In
+                values:
+                - "true"
+      containers:
+      - image: 144563655722.dkr.ecr.eu-west-1.amazonaws.com/congenica/dev/dummy-pathogen-pipeline:1.0.0
+        name: dummy-pathogen-pipeline-minikube
+        imagePullPolicy: Never
+        env:
+        - name: PSGA_ROOT_PATH
+          value: /app
+        - name: PSGA_OUTPUT_PATH
+          value: /data/output
+        - name: PSGA_INCOMPLETE_ANALYSIS_RUNS_PATH
+          value: /data/incomplete_analysis_runs
+        - name: PSGA_MAX_ATTEMPTS
+          value: '3'
+        - name: PSGA_SLEEP_TIME_BETWEEN_ATTEMPTS
+          value: '60'
+        - name: DOCKER_IMAGE_PREFIX
+          value: '144563655722.dkr.ecr.eu-west-1.amazonaws.com/congenica/dev'
+        - name: DUMMY_PATHOGEN_PIPELINE_DOCKER_IMAGE_TAG
+          value: '1.0.0'
+        - name: K8S_NODE
+          value: farmNode
+        - name: K8S_PULL_POLICY
+          value: Never
+        - name: K8S_SERVICE_ACCOUNT
+          value: psga-minikube-admin
+        - name: K8S_QUEUE_SIZE
+          value: '5'
+        - name: K8S_STORAGE_CLAIM_NAME
+          value: psga-minikube-pvc
+        - name: K8S_STORAGE_MOUNT_PATH
+          value: /data
+        - name: K8S_PROCESS_MAX_RETRIES
+          value: '3'
+        - name: K8S_PROCESS_CPU_LOW
+          value: '1'
+        - name: K8S_PROCESS_CPU_HIGH
+          value: '2'
+        - name: K8S_PROCESS_MEMORY_VERY_LOW
+          value: '250'
+        - name: K8S_PROCESS_MEMORY_LOW
+          value: '500'
+        - name: K8S_PROCESS_MEMORY_MEDIUM
+          value: '1000'
+        - name: K8S_PROCESS_MEMORY_HIGH
+          value: '2000'
+        - name: K8S_PROCESS_MEMORY_VERY_HIGH
+          value: '4000'
+        - name: NXF_WORK
+          value: /data/work
+        - name: NXF_EXECUTOR
+          value: k8s
+        - name: NXF_ANSI_LOG
+          value: 'false'
+        - name: NXF_OPTS
+          value: '-Xms1g -Xmx4g'
+        volumeMounts:
+        - name: psga-persistent-storage
+          mountPath: /data
+      serviceAccountName: psga-minikube-admin
+      volumes:
+      - name: psga-persistent-storage
+        persistentVolumeClaim:
+          claimName: psga-minikube-pvc
+

--- a/minikube/startup.sh
+++ b/minikube/startup.sh
@@ -28,3 +28,10 @@ kubectl apply -f deploy_sars_cov_2.yaml
 pipeline_pod="$( kubectl get pods -l app=sars-cov-2-pipeline-minikube --no-headers -o custom-columns=':metadata.name' )"
 wait_for_pod "${pipeline_pod}"
 kubectl cp ${HOME}/.aws ${pipeline_pod}:/root/
+
+
+## deploy dummy-pipeline pipeline
+kubectl apply -f deploy_dummy_pathogen.yaml
+pipeline_pod="$( kubectl get pods -l app=dummy-pathogen-pipeline-minikube --no-headers -o custom-columns=':metadata.name' )"
+wait_for_pod "${pipeline_pod}"
+kubectl cp ${HOME}/.aws ${pipeline_pod}:/root/

--- a/psga/dummy_pathogen/generate_dummy_output.nf
+++ b/psga/dummy_pathogen/generate_dummy_output.nf
@@ -1,0 +1,26 @@
+/*
+ * Generate some dummy output
+ */
+process generate_dummy_output {
+  publishDir "${PSGA_OUTPUT_PATH}/merged_output", mode: 'copy', overwrite: true, pattern: 'pipeline_output.csv'
+
+  input:
+    path ch_input_files
+
+  output:
+    path "pipeline_output.csv", emit: ch_merged_csv_file
+
+  shell:
+  '''
+  merged_csv_file="pipeline_output.csv"
+  echo "sample_id,res1,res2" > ${merged_csv_file}
+
+  for fq in `ls *_1.fastq.gz`; do
+      sample_id=$(echo "${fq}" | cut -d'_' -f1)
+      # returns the seconds and current nanoseconds since the epoch.
+      res2=$(date +%s%N)
+      echo "${sample_id},fastq,${res2}" >> ${merged_csv_file}
+  done
+  '''
+}
+

--- a/psga/dummy_pathogen/help.nf
+++ b/psga/dummy_pathogen/help.nf
@@ -1,0 +1,33 @@
+def printPathogenConfig() {
+
+    log.info"""
+        dummy_pathogen pathogen
+        ===================
+        Environment variables:
+        * <list pathogen-specific env vars here>
+
+        Parameters:
+        * <list pathogen-specific parameters here>
+    """.stripIndent()
+}
+
+def printPathogenHelp() {
+    log.info"""
+        dummy_pathogen pathogen
+          Description:
+            <describe the pathogen analysis here>
+
+          Usage:
+            nextflow run . --run [analysis_run] --metadata [csv] [parameters]
+
+          Mandatory environment variables:
+            <any mandatory env vars here>
+                                    <description>
+
+          Mandatory parameters:
+            <any mandatory parameters here>    <description>
+
+          Optional parameters:
+            <any optional parameters here>    <description>
+    """.stripIndent()
+}

--- a/psga/dummy_pathogen/nextflow.config
+++ b/psga/dummy_pathogen/nextflow.config
@@ -1,0 +1,32 @@
+// load the main config
+includeConfig './common/common.config'
+
+manifest {
+    name = "Congenica PSGA/dummy_pathogen pipeline"
+    description = "Pathogen Sequence Genome Analysis pipeline for dummy_pathogen pathogen"
+    author = 'Congenica'
+    homePage = 'https://www.congenica.com/'
+    mainScript = 'main.nf'
+    nextflowVersion = '>= 21.10.4'
+    version = '1.0.0'
+}
+
+env {
+    // docker image config
+    DUMMY_PATHOGEN_PIPELINE_DOCKER_IMAGE_TAG = "${DUMMY_PATHOGEN_PIPELINE_DOCKER_IMAGE_TAG}"
+}
+
+process {
+
+    withName:fastqc {
+        executor = 'k8s'
+        container = "${env.DOCKER_IMAGE_PREFIX}/dummy-pathogen-pipeline:${env.DUMMY_PATHOGEN_PIPELINE_DOCKER_IMAGE_TAG}"
+        errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
+    }
+
+    withName:generate_dummy_output {
+        executor = 'k8s'
+        container = "${env.DOCKER_IMAGE_PREFIX}/dummy-pathogen-pipeline:${env.DUMMY_PATHOGEN_PIPELINE_DOCKER_IMAGE_TAG}"
+    }
+
+}

--- a/psga/dummy_pathogen/psga.nf
+++ b/psga/dummy_pathogen/psga.nf
@@ -1,0 +1,30 @@
+include { fastqc } from './common/fastqc.nf'
+include { select_sample_file_pair as get_sample_files } from './common/fetch_sample_files.nf'
+include { generate_dummy_output } from './generate_dummy_output.nf'
+
+
+/*
+ * Main workflow for the pathogen: dummy_pathogen.
+ */
+workflow psga {
+
+    main:
+
+        ch_metadata = Channel.fromPath(params.metadata)
+
+        ch_input_files_fastq = get_sample_files(
+            ch_metadata,
+            ".fastq.gz"
+        )
+
+        fastqc(ch_input_files_fastq)
+
+        generate_dummy_output(
+            fastqc.out.ch_input_files.collect()
+        )
+
+        ch_analysis_run_results_submitted = generate_dummy_output.out.ch_merged_csv_file
+
+    emit:
+        ch_analysis_run_results_submitted
+}

--- a/scripts/dummy_pathogen/README
+++ b/scripts/dummy_pathogen/README
@@ -1,0 +1,1 @@
+Add dummy_pathogen-specific Python scripts in this directory


### PR DESCRIPTION
**DO NOT MERGE**
This works only with minikube as the dummy-pathogen-pipeline docker image cannot be pushed to ECR as not registered. 
If you check the `Files changed` tab, this new pipeline was added without affecting the existing sars-cov-2 pipeline.


Example of execution:
```
# deploy on minikube
pierodallepezze@CONGENICA-0256:~/psga-pipeline/minikube$ ./startup.sh 
node/minikube not labeled
namespace/psga-minikube created
Context "minikube" modified.
role.rbac.authorization.k8s.io/psga-minikube-admin created
serviceaccount/psga-minikube-admin created
rolebinding.rbac.authorization.k8s.io/psga-minikube-admin created
persistentvolumeclaim/psga-minikube-pvc created
deployment.apps/sars-cov-2-pipeline-minikube created
waiting for pod sars-cov-2-pipeline-minikube-597f566974-phnmp to run ..
sars-cov-2-pipeline-minikube-597f566974-phnmp is running
deployment.apps/dummy-pathogen-pipeline-minikube created
waiting for pod dummy-pathogen-pipeline-minikube-6cdc5f6d7c-7562n to run ..
dummy-pathogen-pipeline-minikube-6cdc5f6d7c-7562n is running

# two pipelines are coexisting 
pierodallepezze@CONGENICA-0256:~/psga-pipeline/minikube$ kpods 
NAME                                                READY   STATUS    RESTARTS   AGE
dummy-pathogen-pipeline-minikube-6cdc5f6d7c-7562n   1/1     Running   0          4s
sars-cov-2-pipeline-minikube-597f566974-phnmp       1/1     Running   0          7s


# run the dummy pipeline. This runs a specific process called `generate_dummy_output` 
pierodallepezze@CONGENICA-0256:~/psga-pipeline/minikube$ kubectl exec -it dummy-pathogen-pipeline-minikube-6cdc5f6d7c-7562n -- bash 
root@dummy-pathogen-pipeline-minikube-6cdc5f6d7c-7562n:/app/psga# nextflow run . --run dummy_pathogen --metadata s3://synthetic-data-dev/UKHSA/small_tests/illumina_fastq/metadata.csv
N E X T F L O W  ~  version 22.05.0-edge
Launching `./main.nf` [chaotic_franklin] DSL2 - revision: c69e2c0e5d
[c5/c16e3f] Submitted process > psga:get_sample_files:stage_sample_file_pair (2 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fastq.gz, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fastq.gz])
[42/cc257f] Submitted process > psga:get_sample_files:stage_sample_file_pair (1 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[57/9db1c3] Submitted process > psga:fastqc (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fastq.gz, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fastq.gz])
[19/2b9493] Submitted process > psga:fastqc (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[58/3e7e06] Submitted process > psga:generate_dummy_output
[f2/35ca71] Submitted process > pipeline_end


# Output file generated by the dummy-pipeline
root@dummy-pathogen-pipeline-minikube-6cdc5f6d7c-7562n:/app/psga# cat /data/output/merged_output/pipeline_output.csv 
sample_id,res1,res2
9729bce7-f0a9-4617-b6e0-6145307741d1,fastq,1658419855564878218
aff01b7c-8a0a-40bf-927a-0548add8ea5a,fastq,1658419855567843243
```