### PR TITLE
PSG-670: enable test validation for V4 illumina / ont sample

### DIFF
--- a/jenkins/files/sars_cov_2/small_tests/Jenkinsfile
+++ b/jenkins/files/sars_cov_2/small_tests/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
                             build (
                                 job: "${PSGA_PIPELINE}/${env.BRANCH_NAME}",
                                 parameters: [
-                                        booleanParam(name: 'VALIDATION_TEST', value: false),
+                                        booleanParam(name: 'VALIDATION_TEST', value: true),
                                         string(name: 'METADATA', value: "s3://synthetic-data-dev/UKHSA/requirements/CL0015b/illumina_v4_input/metadata.csv"),
                                         string(name: 'PSGA_OUTPUT_PATH', value: "/data/output/illumina_v4"),
                                         string(name: 'NXF_WORK', value: "/data/work/illumina_v4"),
@@ -70,7 +70,7 @@ pipeline {
                             build (
                                 job: "${PSGA_PIPELINE}/${env.BRANCH_NAME}",
                                 parameters: [
-                                        booleanParam(name: 'VALIDATION_TEST', value: false),
+                                        booleanParam(name: 'VALIDATION_TEST', value: true),
                                         string(name: 'METADATA', value: "s3://synthetic-data-dev/UKHSA/requirements/CL0015b/ont_v4_input/metadata.csv"),
                                         string(name: 'PSGA_OUTPUT_PATH', value: "/data/output/ont_v4"),
                                         string(name: 'NXF_WORK', value: "/data/work/ont_v4"),


### PR DESCRIPTION
This change runs the validation for the V4 samples as part of our integration test (small_tests).