### PR TITLE
PSG-605: enable ONT workflow to process bam samples. 

### DIFF
--- a/psga/common/utils.nf
+++ b/psga/common/utils.nf
@@ -1,21 +1,21 @@
 /*
- * Convert a BAM file into FASTQ (2 reads)
+ * Convert a BAM file to illumina FASTQ (2 reads)
  */
-process bam_to_fastq {
+process bam_to_fastq_illumina {
   tag "${task.index} - ${bam}"
   input:
     file bam
 
   output:
-    path "${fastq_directory}/*", emit: ch_bam_to_fastq_files
+    path "${fastq_directory}/*", emit: ch_bam_to_fastq
 
   script:
     sample_name = "${bam.baseName}"
     fastq_preproc = "fastq_preproc"
     fastq_directory = "fastq_files"
     // illumina suffix format
-    fastq_suffix_1 = "_1.fastq"
-    fastq_suffix_2 = "_2.fastq"
+    fastq_suffix_1 = "_1.fastq.gz"
+    fastq_suffix_2 = "_2.fastq.gz"
 
   """
   mkdir -p ${fastq_preproc}
@@ -27,8 +27,24 @@ process bam_to_fastq {
   # Starting from a coordinate sorted file, output paired reads to separate files, discarding singletons, supplementary and secondary reads. The resulting files can be used with, for example, the bwa aligner.
   # see: http://www.htslib.org/doc/samtools-fasta.html
   samtools collate -u -O ${fastq_preproc}/${sample_name}.sorted.bam | samtools fastq -1 ${fastq_directory}/${sample_name}${fastq_suffix_1} -2  ${fastq_directory}/${sample_name}${fastq_suffix_2} -0 /dev/null -s /dev/null -n
+  """
+}
 
-  bgzip -f ${fastq_directory}/${sample_name}${fastq_suffix_1}
-  bgzip -f ${fastq_directory}/${sample_name}${fastq_suffix_2}
+/*
+ * Convert a BAM file to ONT FASTQ
+ */
+process bam_to_fastq_ont {
+  tag "${task.index} - ${bam}"
+  input:
+    file bam
+
+  output:
+    path "${fastq_output}", emit: ch_bam_to_fastq
+
+  script:
+    fastq_output = "${bam.baseName}.fastq"
+  """
+  # write singleton reads to (decompressed) fastq file. Do not append /1 and 2/ to the read name
+  samtools bam2fq -nO ${bam} > ${fastq_output}
   """
 }

--- a/psga/sars_cov_2/nextflow.config
+++ b/psga/sars_cov_2/nextflow.config
@@ -59,7 +59,7 @@ process {
     }
 
     if ( params.sequencing_technology == "illumina" ) {
-        withName:bam_to_fastq {
+        withName:bam_to_fastq_illumina {
             executor = 'k8s'
             container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019-artic-nf-illumina:${env.NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG}"
             memory = { "${env.K8S_PROCESS_MEMORY_HIGH}" as int * 1.MB * task.attempt }
@@ -83,6 +83,13 @@ process {
             errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
         }
     } else if ( params.sequencing_technology == "ont" ) {
+        withName:bam_to_fastq_ont {
+            executor = 'k8s'
+            container = "${env.DOCKER_IMAGE_PREFIX}/ncov2019-artic-nf-nanopore:${env.NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG}"
+            memory = { "${env.K8S_PROCESS_MEMORY_HIGH}" as int * 1.MB * task.attempt }
+            errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
+        }
+
         withName:contamination_removal_ont {
             executor = 'k8s'
             container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"

--- a/scripts/sars_cov_2/check_metadata.py
+++ b/scripts/sars_cov_2/check_metadata.py
@@ -29,14 +29,22 @@ SEQUENCING_TECHNOLOGIES = [ILLUMINA, ONT, UNKNOWN]
 FILE_NUM = "file_num"
 SUPPORTED_FILES = {
     ILLUMINA: {
+        "fastq": {FILE_NUM: 2},
         "fastq.gz": {FILE_NUM: 2},
+        "fq": {FILE_NUM: 2},
+        "fq.gz": {FILE_NUM: 2},
         "bam": {FILE_NUM: 1},
     },
     ONT: {
         "fastq": {FILE_NUM: 1},
+        "fastq.gz": {FILE_NUM: 1},
+        "fq": {FILE_NUM: 1},
+        "fq.gz": {FILE_NUM: 1},
+        "bam": {FILE_NUM: 1},
     },
     UNKNOWN: {
         "fasta": {FILE_NUM: 1},
+        "fa": {FILE_NUM: 1},
     },
 }
 

--- a/tests/sars_cov_2/test_check_metadata.py
+++ b/tests/sars_cov_2/test_check_metadata.py
@@ -9,9 +9,16 @@ from utils_tests import read_samples_from_file
     "metadata_file,sequencing_technology,valid_samples,invalid_samples",
     [
         (
-            "good_metadata_illumina_bam.csv",
+            "good_metadata_illumina.csv",
             "illumina",
-            ["37a36d1c-5985-4836-87b5-b36bac75d81b", "985347c5-ff6a-454c-ac34-bc353d05dd70"],
+            [
+                "37a36d1c-5985-4836-87b5-b36bac75d81b",
+                "57a36d1c-5985-4836-87b5-b36bac75d81b",
+                "885347c5-ff6a-454c-ac34-bc353d05dd70",
+                "985347c5-ff6a-454c-ac34-bc353d05dd70",
+                "47a36d1c-5985-4836-87b5-b36bac75d81b",
+                "485347c5-ff6a-454c-ac34-bc353d05dd70",
+            ],
             [],
         ),
         (
@@ -49,48 +56,13 @@ def test_validate_metadata(
     [
         # CORRECT METADATA
         (
-            "good_metadata_illumina_fastq.csv",
-            "just_a_name",
-            "illumina",
-            ["37a36d1c-5985-4836-87b5-b36bac75d81b", "985347c5-ff6a-454c-ac34-bc353d05dd70"],
-            [],
-            0,
-            None,
-        ),
-        (
-            "good_metadata_illumina_bam.csv",
-            "just_a_name",
-            "illumina",
-            ["37a36d1c-5985-4836-87b5-b36bac75d81b", "985347c5-ff6a-454c-ac34-bc353d05dd70"],
-            [],
-            0,
-            None,
-        ),
-        (
-            "good_metadata_medaka_fastq.csv",
-            "just_a_name",
-            "ont",
-            ["37a36d1c-5985-4836-87b5-b36bac75d81b", "985347c5-ff6a-454c-ac34-bc353d05dd70"],
-            [],
-            0,
-            None,
-        ),
-        (
-            "good_metadata_fasta.csv",
-            "just_a_name",
-            "unknown",
-            ["37a36d1c-5985-4836-87b5-b36bac75d81b", "985347c5-ff6a-454c-ac34-bc353d05dd70"],
-            [],
-            0,
-            None,
-        ),
-        # combined illumina fastq and bam in 1 single metadata file
-        (
-            "good_metadata_illumina_fastq_bam.csv",
+            "good_metadata_illumina.csv",
             "just_a_name",
             "illumina",
             [
                 "37a36d1c-5985-4836-87b5-b36bac75d81b",
+                "57a36d1c-5985-4836-87b5-b36bac75d81b",
+                "885347c5-ff6a-454c-ac34-bc353d05dd70",
                 "985347c5-ff6a-454c-ac34-bc353d05dd70",
                 "47a36d1c-5985-4836-87b5-b36bac75d81b",
                 "485347c5-ff6a-454c-ac34-bc353d05dd70",
@@ -99,9 +71,34 @@ def test_validate_metadata(
             0,
             None,
         ),
+        (
+            "good_metadata_ont.csv",
+            "just_a_name",
+            "ont",
+            [
+                "37a36d1c-5985-4836-87b5-b36bac75d81b",
+                "57a36d1c-5985-4836-87b5-b36bac75d81b",
+                "885347c5-ff6a-454c-ac34-bc353d05dd70",
+                "985347c5-ff6a-454c-ac34-bc353d05dd70",
+                "47a36d1c-5985-4836-87b5-b36bac75d81b",
+                "485347c5-ff6a-454c-ac34-bc353d05dd70",
+            ],
+            [],
+            0,
+            None,
+        ),
+        (
+            "good_metadata_fasta.csv",
+            "just_a_name",
+            "unknown",
+            ["37a36d1c-5985-4836-87b5-b36bac75d81b", "985347c5-ff6a-454c-ac34-bc353d05dd70"],
+            [],
+            0,
+            None,
+        ),
         # CORRECT METADATA, INCORRECT sequencing_technology
         (
-            "good_metadata_illumina_fastq.csv",
+            "good_metadata_illumina.csv",
             "just_a_name",
             "fake_technology",
             [],
@@ -110,52 +107,81 @@ def test_validate_metadata(
             "Error: Invalid value for '--sequencing-technology'",
         ),
         (
-            "good_metadata_illumina_fastq.csv",
+            "good_metadata_illumina.csv",
             "just_a_name",
             "ont",
+            [
+                "37a36d1c-5985-4836-87b5-b36bac75d81b",
+                "47a36d1c-5985-4836-87b5-b36bac75d81b",
+                "485347c5-ff6a-454c-ac34-bc353d05dd70",
+                "57a36d1c-5985-4836-87b5-b36bac75d81b",
+                "885347c5-ff6a-454c-ac34-bc353d05dd70",
+                "985347c5-ff6a-454c-ac34-bc353d05dd70",
+            ],
             [],
-            ["37a36d1c-5985-4836-87b5-b36bac75d81b", "985347c5-ff6a-454c-ac34-bc353d05dd70"],
-            1,
-            "Invalid row for SAMPLE_ID 37a36d1c-5985-4836-87b5-b36bac75d81b:\n"
-            + "SAMPLE_ID: 37a36d1c-5985-4836-87b5-b36bac75d81b has invalid file for sequencing technology ont. "
-            + "Supported files are ['fastq']\n"
-            + "Invalid row for SAMPLE_ID 985347c5-ff6a-454c-ac34-bc353d05dd70:\n"
-            + "SAMPLE_ID: 985347c5-ff6a-454c-ac34-bc353d05dd70 has invalid file for sequencing technology ont. "
-            + "Supported files are ['fastq']\n"
-            + "Error: Errors encountered for sample ids: "
-            + "37a36d1c-5985-4836-87b5-b36bac75d81b, 985347c5-ff6a-454c-ac34-bc353d05dd70\n",
+            0,
+            None,
         ),
         (
-            "good_metadata_medaka_fastq.csv",
+            "good_metadata_ont.csv",
             "just_a_name",
             "illumina",
-            [],
-            ["37a36d1c-5985-4836-87b5-b36bac75d81b", "985347c5-ff6a-454c-ac34-bc353d05dd70"],
+            ["47a36d1c-5985-4836-87b5-b36bac75d81b", "485347c5-ff6a-454c-ac34-bc353d05dd70"],
+            [
+                "37a36d1c-5985-4836-87b5-b36bac75d81b",
+                "57a36d1c-5985-4836-87b5-b36bac75d81b",
+                "885347c5-ff6a-454c-ac34-bc353d05dd70",
+                "985347c5-ff6a-454c-ac34-bc353d05dd70",
+            ],
             1,
             "Invalid row for SAMPLE_ID 37a36d1c-5985-4836-87b5-b36bac75d81b:\n"
-            + "SAMPLE_ID: 37a36d1c-5985-4836-87b5-b36bac75d81b has invalid file for sequencing technology illumina. "
-            + "Supported files are ['fastq.gz', 'bam']\n"
+            + "SEQ_FILE_2 for 37a36d1c-5985-4836-87b5-b36bac75d81b not available\n"
+            + "Invalid row for SAMPLE_ID 57a36d1c-5985-4836-87b5-b36bac75d81b:\n"
+            + "SEQ_FILE_2 for 57a36d1c-5985-4836-87b5-b36bac75d81b not available\n"
+            + "Invalid row for SAMPLE_ID 885347c5-ff6a-454c-ac34-bc353d05dd70:\n"
+            + "SEQ_FILE_2 for 885347c5-ff6a-454c-ac34-bc353d05dd70 not available\n"
             + "Invalid row for SAMPLE_ID 985347c5-ff6a-454c-ac34-bc353d05dd70:\n"
-            + "SAMPLE_ID: 985347c5-ff6a-454c-ac34-bc353d05dd70 has invalid file for sequencing technology illumina. "
-            + "Supported files are ['fastq.gz', 'bam']\n"
+            + "SEQ_FILE_2 for 985347c5-ff6a-454c-ac34-bc353d05dd70 not available\n"
             + "Error: Errors encountered for sample ids: "
-            + "37a36d1c-5985-4836-87b5-b36bac75d81b, 985347c5-ff6a-454c-ac34-bc353d05dd70\n",
+            + "37a36d1c-5985-4836-87b5-b36bac75d81b, 57a36d1c-5985-4836-87b5-b36bac75d81b, "
+            + "885347c5-ff6a-454c-ac34-bc353d05dd70, 985347c5-ff6a-454c-ac34-bc353d05dd70\n",
         ),
         (
-            "good_metadata_medaka_fastq.csv",
+            "good_metadata_ont.csv",
             "just_a_name",
             "unknown",
             [],
-            ["37a36d1c-5985-4836-87b5-b36bac75d81b", "985347c5-ff6a-454c-ac34-bc353d05dd70"],
+            [
+                "37a36d1c-5985-4836-87b5-b36bac75d81b",
+                "47a36d1c-5985-4836-87b5-b36bac75d81b",
+                "485347c5-ff6a-454c-ac34-bc353d05dd70",
+                "57a36d1c-5985-4836-87b5-b36bac75d81b",
+                "885347c5-ff6a-454c-ac34-bc353d05dd70",
+                "985347c5-ff6a-454c-ac34-bc353d05dd70",
+            ],
             1,
             "Invalid row for SAMPLE_ID 37a36d1c-5985-4836-87b5-b36bac75d81b:\n"
             + "SAMPLE_ID: 37a36d1c-5985-4836-87b5-b36bac75d81b has invalid file for sequencing technology unknown. "
-            + "Supported files are ['fasta']\n"
+            + "Supported files are ['fasta', 'fa']\n"
+            + "Invalid row for SAMPLE_ID 57a36d1c-5985-4836-87b5-b36bac75d81b:\n"
+            + "SAMPLE_ID: 57a36d1c-5985-4836-87b5-b36bac75d81b has invalid file for sequencing technology unknown. "
+            + "Supported files are ['fasta', 'fa']\n"
+            + "Invalid row for SAMPLE_ID 885347c5-ff6a-454c-ac34-bc353d05dd70:\n"
+            + "SAMPLE_ID: 885347c5-ff6a-454c-ac34-bc353d05dd70 has invalid file for sequencing technology unknown. "
+            + "Supported files are ['fasta', 'fa']\n"
             + "Invalid row for SAMPLE_ID 985347c5-ff6a-454c-ac34-bc353d05dd70:\n"
             + "SAMPLE_ID: 985347c5-ff6a-454c-ac34-bc353d05dd70 has invalid file for sequencing technology unknown. "
-            + "Supported files are ['fasta']\n"
+            + "Supported files are ['fasta', 'fa']\n"
+            + "Invalid row for SAMPLE_ID 47a36d1c-5985-4836-87b5-b36bac75d81b:\n"
+            + "SAMPLE_ID: 47a36d1c-5985-4836-87b5-b36bac75d81b has invalid file for sequencing technology unknown. "
+            + "Supported files are ['fasta', 'fa']\n"
+            + "Invalid row for SAMPLE_ID 485347c5-ff6a-454c-ac34-bc353d05dd70:\n"
+            + "SAMPLE_ID: 485347c5-ff6a-454c-ac34-bc353d05dd70 has invalid file for sequencing technology unknown. "
+            + "Supported files are ['fasta', 'fa']\n"
             + "Error: Errors encountered for sample ids: "
-            + "37a36d1c-5985-4836-87b5-b36bac75d81b, 985347c5-ff6a-454c-ac34-bc353d05dd70\n",
+            + "37a36d1c-5985-4836-87b5-b36bac75d81b, 47a36d1c-5985-4836-87b5-b36bac75d81b, "
+            + "485347c5-ff6a-454c-ac34-bc353d05dd70, 57a36d1c-5985-4836-87b5-b36bac75d81b, "
+            + "885347c5-ff6a-454c-ac34-bc353d05dd70, 985347c5-ff6a-454c-ac34-bc353d05dd70\n",
         ),
         (
             "good_metadata_fasta.csv",
@@ -166,10 +192,10 @@ def test_validate_metadata(
             1,
             "Invalid row for SAMPLE_ID 37a36d1c-5985-4836-87b5-b36bac75d81b:\n"
             + "SAMPLE_ID: 37a36d1c-5985-4836-87b5-b36bac75d81b has invalid file for sequencing technology ont. "
-            + "Supported files are ['fastq']\n"
+            + "Supported files are ['fastq', 'fastq.gz', 'fq', 'fq.gz', 'bam']\n"
             + "Invalid row for SAMPLE_ID 985347c5-ff6a-454c-ac34-bc353d05dd70:\n"
             + "SAMPLE_ID: 985347c5-ff6a-454c-ac34-bc353d05dd70 has invalid file for sequencing technology ont. "
-            + "Supported files are ['fastq']\n"
+            + "Supported files are ['fastq', 'fastq.gz', 'fq', 'fq.gz', 'bam']\n"
             + "Error: Errors encountered for sample ids: "
             + "37a36d1c-5985-4836-87b5-b36bac75d81b, 985347c5-ff6a-454c-ac34-bc353d05dd70\n",
         ),
@@ -196,7 +222,7 @@ def test_validate_metadata(
             + "SEQ_FILE_1 for 185347c5-ff6a-454c-ac34-bc353d05dd70 not available\n"
             + "Invalid row for SAMPLE_ID 186647c5-ff6a-454c-ac34-bc353d05dd70:\n"
             + "SAMPLE_ID: 186647c5-ff6a-454c-ac34-bc353d05dd70 has invalid file for sequencing technology illumina. "
-            + "Supported files are ['fastq.gz', 'bam']\n"
+            + "Supported files are ['fastq', 'fastq.gz', 'fq', 'fq.gz', 'bam']\n"
             + "Invalid row for SAMPLE_ID 27a36d1c-5985-4836-87b5-b36bac75d81b:\n"
             + "SEQ_FILE_2 for 27a36d1c-5985-4836-87b5-b36bac75d81b not available\n"
             + "Invalid row for SAMPLE_ID 286647c5-ff6a-454c-ac34-bc353d05dd70:\n"

--- a/tests/test_data/good_metadata_fasta.csv
+++ b/tests/test_data/good_metadata_fasta.csv
@@ -1,3 +1,3 @@
 SAMPLE_ID,SEQ_FILE_1,SEQ_FILE_2
-37a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/small_tests/illumina_fasta/ERR7150151.fasta,
-985347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/small_tests/illumina_fasta/ERR7150243.fasta,
+37a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/fasta/ERR7150151.fasta,
+985347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/fasta/ERR7150243.fa,

--- a/tests/test_data/good_metadata_illumina.csv
+++ b/tests/test_data/good_metadata_illumina.csv
@@ -1,0 +1,7 @@
+SAMPLE_ID,SEQ_FILE_1,SEQ_FILE_2
+37a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/illumina/ERR7150151_1.fastq.gz,s3://synthetic-data-dev/illumina/ERR7150151_2.fastq.gz
+57a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/illumina/ERR7150151_1.fastq,s3://synthetic-data-dev/illumina/ERR7150151_2.fastq
+885347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/illumina/ERR7150243_1.fq.gz,s3://synthetic-data-dev/illumina/ERR7150243_2.fq.gz
+985347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/illumina/ERR7150243_1.fq,s3://synthetic-data-dev/illumina/ERR7150243_2.fq
+47a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/illumina/ERR7150151.bam,
+485347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/illumina/ERR7150243.bam,

--- a/tests/test_data/good_metadata_illumina_bam.csv
+++ b/tests/test_data/good_metadata_illumina_bam.csv
@@ -1,3 +1,0 @@
-SAMPLE_ID,SEQ_FILE_1,SEQ_FILE_2
-37a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/small_tests/illumina_bam/ERR7150151.bam,
-985347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/small_tests/illumina_bam/ERR7150243.bam,

--- a/tests/test_data/good_metadata_illumina_fastq.csv
+++ b/tests/test_data/good_metadata_illumina_fastq.csv
@@ -1,3 +1,0 @@
-SAMPLE_ID,SEQ_FILE_1,SEQ_FILE_2
-37a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/small_tests/illumina_fastq/ERR7150151_1.fastq.gz,s3://synthetic-data-dev/small_tests/illumina_fastq/ERR7150151_2.fastq.gz
-985347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/small_tests/illumina_fastq/ERR7150243_1.fastq.gz,s3://synthetic-data-dev/small_tests/illumina_fastq/ERR7150243_2.fastq.gz

--- a/tests/test_data/good_metadata_illumina_fastq_bam.csv
+++ b/tests/test_data/good_metadata_illumina_fastq_bam.csv
@@ -1,5 +1,0 @@
-SAMPLE_ID,SEQ_FILE_1,SEQ_FILE_2
-37a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/small_tests/illumina_fastq/ERR7150151_1.fastq.gz,s3://synthetic-data-dev/small_tests/illumina_fastq/ERR7150151_2.fastq.gz
-985347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/small_tests/illumina_fastq/ERR7150243_1.fastq.gz,s3://synthetic-data-dev/small_tests/illumina_fastq/ERR7150243_2.fastq.gz
-47a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/small_tests/illumina_bam/ERR7150151.bam,
-485347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/small_tests/illumina_bam/ERR7150243.bam,

--- a/tests/test_data/good_metadata_medaka_fastq.csv
+++ b/tests/test_data/good_metadata_medaka_fastq.csv
@@ -1,3 +1,0 @@
-SAMPLE_ID,SEQ_FILE_1,SEQ_FILE_2
-37a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/small_tests/medaka_fastq/ERR7150151.fastq,
-985347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/small_tests/medaka_fastq/ERR7150243.fastq,

--- a/tests/test_data/good_metadata_ont.csv
+++ b/tests/test_data/good_metadata_ont.csv
@@ -1,0 +1,7 @@
+SAMPLE_ID,SEQ_FILE_1,SEQ_FILE_2
+37a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/ont/ERR7150151.fastq.gz,
+57a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/ont/ERR7150151.fastq,
+885347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/ont/ERR7150243.fq.gz,
+985347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/ont/ERR7150243.fq,
+47a36d1c-5985-4836-87b5-b36bac75d81b,s3://synthetic-data-dev/ont/ERR7150151.bam,
+485347c5-ff6a-454c-ac34-bc353d05dd70,s3://synthetic-data-dev/ont/ERR7150243.bam,


### PR DESCRIPTION
Changes:
* enable ONT to process bam samples
* For consistency and to facilitate the task above, extend acceptable input file types for ONT and ILLUMINA. These are: fastq, fastq.gz, fq, fq.gz and bam. I also extended the acceptable inputs for fasta files. Now also "fa" is supported.
* update unit tests accordingly
* updated "small-tests" integration tests to include the different combinations of file types. See metadata.csv files in: `jenkins/files/sars_cov_2/small_tests/Jenkinsfile`. Of course, files were generated / updated on s3. For Ont, a bam file was added to the integration test.


Testing:
* See slack: `psga-pipeline-ci` for 5 existing small-tests.