### PR TITLE
PSG-728: generate pipeline results even if all samples fail in the analysis run

### DIFF
--- a/docker/Dockerfile.psga-pipeline
+++ b/docker/Dockerfile.psga-pipeline
@@ -8,10 +8,10 @@ ARG pathogen
 
 COPY ./psga/common /app/psga/common
 COPY ./psga/${pathogen} ./psga/*.py ./psga/*.sh ./psga/main.nf /app/psga/
+COPY ./pyproject.toml ./poetry.lock ./app/
 COPY ./scripts/util /app/scripts/util
 COPY ./scripts/validation /app/scripts/validation
 COPY ./scripts/${pathogen} /app/scripts/${pathogen}
-COPY ./pyproject.toml ./poetry.lock ./app/
 
 # scripts for running the validation following integration tests execution
 COPY ./jenkins/*.py ./app/jenkins/
@@ -23,5 +23,8 @@ RUN pip install --progress-bar=off --no-cache-dir --upgrade pip==${PIP_VERSION} 
     # make poetry install everything system wide, no need for a virtualenv in docker
     poetry config virtualenvs.create false && \
     poetry install --no-interaction --no-ansi --no-dev
+
+# generic construct if scripts must be executed at this stage (e.g. for generating default files)
+RUN if [ -f /app/scripts/${pathogen}/Makefile ]; then cd /app/scripts/${pathogen} && make; fi;
 
 ENTRYPOINT ["python", "autoresumer.py"]

--- a/jenkins/files/sars_cov_2/small_tests/Jenkinsfile
+++ b/jenkins/files/sars_cov_2/small_tests/Jenkinsfile
@@ -136,7 +136,24 @@ pipeline {
                         }
                     }
                 }
-            }
+                stage('failing_illumina_samples') {
+                    steps {
+                        script {
+                            build (
+                                job: "${PSGA_PIPELINE}/${env.BRANCH_NAME}",
+                                parameters: [
+                                        booleanParam(name: 'VALIDATION_TEST', value: false),
+                                        string(name: 'METADATA', value: "s3://synthetic-data-dev/UKHSA/from_them/gold_standard/illumina/v4/2022-08-18/pipeline_metadata.csv"),
+                                        string(name: 'OUTPUT_PATH', value: "/data/output/empty_sample_and_sample_failing_ncov_qc"),
+                                        string(name: 'NXF_WORK', value: "/data/work/empty_sample_and_sample_failing_ncov_qc"),
+                                        string(name: 'ANALYSIS_RUN', value: "empty_sample_and_sample_failing_ncov_qc"),
+                                        string(name: 'SEQUENCING_TECHNOLOGY', value: "illumina"),
+                                        string(name: 'KIT', value: "V4"),
+                                ]
+                            )
+                        }
+                    }
+                }            }
         }
     }
 }

--- a/psga/sars_cov_2/nextflow.config
+++ b/psga/sars_cov_2/nextflow.config
@@ -36,6 +36,8 @@ params {
     /* pipeline internal parameters */
     // read-it-and-keep reference genome fasta without the poly-A tail
     rik_ref_genome_fasta = "/usr/local/read-it-and-keep/MN908947.3.no_poly_A.fa"
+    ncov_qc_empty_csv = "/app/scripts/sars_cov_2/ncov_qc_empty.csv"
+    pangolin_empty_csv = "/app/scripts/sars_cov_2/pangolin_empty.csv"
 }
 
 process {

--- a/psga/sars_cov_2/submit_analysis_run_results.nf
+++ b/psga/sars_cov_2/submit_analysis_run_results.nf
@@ -120,11 +120,13 @@ workflow submit_analysis_run_results {
 
         submit_pangolin_results(ch_pangolin_csvs.collect())
 
+        // if the channel is empty, ifEmpty(file(<default_header>)) is used
+        // so that this process is always triggered
         submit_pipeline_results_files(
             params.run,
             ch_metadata,
-            ch_ncov_submitted,
-            submit_pangolin_results.out.ch_pangolin_all_lineages,
+            ch_ncov_submitted.ifEmpty(file(params.ncov_qc_empty_csv)),
+            submit_pangolin_results.out.ch_pangolin_all_lineages.ifEmpty(file(params.pangolin_empty_csv)),
         )
 
         ch_analysis_run_results_submitted = submit_pipeline_results_files.out.ch_output_csv_file

--- a/scripts/sars_cov_2/Makefile
+++ b/scripts/sars_cov_2/Makefile
@@ -1,0 +1,2 @@
+all:
+	python generate_default_files.py

--- a/scripts/sars_cov_2/generate_default_files.py
+++ b/scripts/sars_cov_2/generate_default_files.py
@@ -1,0 +1,29 @@
+from typing import Set
+import csv
+import click
+
+from scripts.sars_cov_2.generate_pipeline_results_files import EXPECTED_NCOV_HEADERS, EXPECTED_PANGOLIN_HEADERS
+
+
+def write_csv(filename: str, fieldnames: Set[str]) -> None:
+    with open(filename, "w", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+
+
+@click.command()
+def generate_default_files() -> None:
+    """
+    Generate empty CSV files for ncov and pangolin. These are used as default results,
+    if the corresponding nextflow channel is empty.
+    This script is used by the dockerfile. It is not used by the pipeline directly.
+
+    This scripts was implemented so that the expected headers are not replicated
+    """
+    write_csv("ncov_qc_empty.csv", EXPECTED_NCOV_HEADERS)
+    write_csv("pangolin_empty.csv", EXPECTED_PANGOLIN_HEADERS)
+
+
+if __name__ == "__main__":
+    # pylint: disable=no-value-for-parameter
+    generate_default_files()


### PR DESCRIPTION
**Changes:**
Generate default CSV files for ncov and pangolin. Therefore, if the channel is empty, these CVS files are used so that result files are always generated.

**Testing:** 
This analysis run was executed for the UKHSA/M1. Whilst the pipeline identifies that the two input samples had issues, it did not generate the result.csv file. 
With this change, it does.
NOTE: I've added this test to the integration tests.

```
root@sars-cov-2-pipeline-minikube-787cfc87b9-zgbj8:/app/psga# nextflow run . --run illumina_fail --sequencing_technology illumina --kit V4 --metadata s3://synthetic-data-dev/UKHSA/from_them/gold_standard/illumina/v4/2022-08-18/pipeline_metadata.csv --output_path /data/output/illumina_fail
N E X T F L O W  ~  version 22.05.0-edge
Launching `./main.nf` [scruffy_sax] DSL2 - revision: b450160779
[7a/3912f0] Submitted process > psga:pipeline_start
[ce/3ef53e] Submitted process > psga:check_metadata (pipeline_metadata.csv)
[6f/8df433] Submitted process > psga:stage_fastq_sample_file (2 - [7170ef62-3e60-4219-9d1b-5fbe17ff0345_R1.fastq, 7170ef62-3e60-4219-9d1b-5fbe17ff0345_R2.fastq])
[00/7b86c8] Submitted process > psga:contamination_removal (1 - [7170ef62-3e60-4219-9d1b-5fbe17ff0345_R1.fastq, 7170ef62-3e60-4219-9d1b-5fbe17ff0345_R2.fastq])
[86/e03294] Submitted process > psga:stage_fastq_sample_file (1 - [70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_R1.fastq, 70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_R2.fastq])
[96/d1c4db] Submitted process > psga:contamination_removal (2 - [70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_R1.fastq, 70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_R2.fastq])
[00/7b86c8] NOTE: Process `psga:contamination_removal (1 - [7170ef62-3e60-4219-9d1b-5fbe17ff0345_R1.fastq, 7170ef62-3e60-4219-9d1b-5fbe17ff0345_R2.fastq])` terminated with an error exit status (1) -- Execution is retried (1)
[3c/e2d148] Re-submitted process > psga:contamination_removal (1 - [7170ef62-3e60-4219-9d1b-5fbe17ff0345_R1.fastq, 7170ef62-3e60-4219-9d1b-5fbe17ff0345_R2.fastq])
[3c/e2d148] NOTE: Process `psga:contamination_removal (1 - [7170ef62-3e60-4219-9d1b-5fbe17ff0345_R1.fastq, 7170ef62-3e60-4219-9d1b-5fbe17ff0345_R2.fastq])` terminated with an error exit status (1) -- Execution is retried (2)
[4e/848934] Submitted process > psga:fastqc (1 - [70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_1.fastq.gz, 70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_2.fastq.gz])
[a9/2c2655] Re-submitted process > psga:contamination_removal (1 - [7170ef62-3e60-4219-9d1b-5fbe17ff0345_R1.fastq, 7170ef62-3e60-4219-9d1b-5fbe17ff0345_R2.fastq])
[a9/2c2655] NOTE: Process `psga:contamination_removal (1 - [7170ef62-3e60-4219-9d1b-5fbe17ff0345_R1.fastq, 7170ef62-3e60-4219-9d1b-5fbe17ff0345_R2.fastq])` terminated with an error exit status (1) -- Execution is retried (3)
[70/264d17] Re-submitted process > psga:contamination_removal (1 - [7170ef62-3e60-4219-9d1b-5fbe17ff0345_R1.fastq, 7170ef62-3e60-4219-9d1b-5fbe17ff0345_R2.fastq])
[70/264d17] NOTE: Process `psga:contamination_removal (1 - [7170ef62-3e60-4219-9d1b-5fbe17ff0345_R1.fastq, 7170ef62-3e60-4219-9d1b-5fbe17ff0345_R2.fastq])` terminated with an error exit status (1) -- Error is ignored
[4f/395e55] Submitted process > psga:ncov2019_artic (1 - [70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_1.fastq.gz, 70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_2.fastq.gz])
[97/37c174] Submitted process > psga:reheader:reheader_fasta (1 - [70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32.qc.csv, 70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32.primertrimmed.consensus.fa])
[f2/881b24] Submitted process > psga:submit_analysis_run_results:submit_ncov_results
[0a/9d4043] Submitted process > psga:reheader:store_reheadered_qc_failed_fasta (1 - 70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32.fasta)
[7c/66ac69] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
[cf/270240] Submitted process > pipeline_end

root@sars-cov-2-pipeline-minikube-787cfc87b9-zgbj8:/app/psga# cat /data/output/illumina_fail/results.csv 
SAMPLE_ID,STATUS,PCT_N_BASES,PCT_COVERED_BASES,LONGEST_NO_N_RUN,NUM_ALIGNED_READS,QC_PASS,QC_STATUS,CONFLICT,QC_NOTES,IS_DESIGNATED,PANGOLIN_VERSION,AMBIGUITY_SCORE,LINEAGE,SCORPIO_VERSION,VERSION,SCORPIO_SUPPORT,SCORPIO_CALL,SCORPIO_CONFLICT,CONSTELLATION_VERSION,NOTE,SCORPIO_NOTES
70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32,Completed,99.89,0.11,33.0,9280.0,False,,,,,,,,,,,,,,,
7170ef62-3e60-4219-9d1b-5fbe17ff0345,Failed,,,,,,,,,,,,,,,,,,,,

root@sars-cov-2-pipeline-minikube-787cfc87b9-zgbj8:/app/psga# cat /data/output/illumina_fail/resultfiles.json 
{
    "70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32": [
        "/data/output/illumina_fail/contamination_removal/cleaned_fastq/70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_1.fastq.gz",
        "/data/output/illumina_fail/contamination_removal/cleaned_fastq/70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_2.fastq.gz",
        "/data/output/illumina_fail/contamination_removal/counting/70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32.txt",
        "/data/output/illumina_fail/fastqc/70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_1_fastqc.zip",
        "/data/output/illumina_fail/fastqc/70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32_2_fastqc.zip",
        "/data/output/illumina_fail/ncov2019-artic/output_fasta/70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32.primertrimmed.consensus.fa",
        "/data/output/illumina_fail/ncov2019-artic/output_plots/70fd6fd3-6eed-48a4-8e5d-d59ecb1dbf32.depth.png"
    ],
    "7170ef62-3e60-4219-9d1b-5fbe17ff0345": []
}
```
