### PR TITLE
PSG-951: assign "none" to --kit if samples are fasta

### DIFF
--- a/jenkins/files/sars_cov_2/large_tests/Jenkinsfile
+++ b/jenkins/files/sars_cov_2/large_tests/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
                                             string(name: 'NXF_WORK', value: "/data/work/no_ncov_fasta_large"),
                                             string(name: 'ANALYSIS_RUN', value: "no_ncov_fasta_large"),
                                             string(name: 'SEQUENCING_TECHNOLOGY', value: "unknown"),
-                                            string(name: 'KIT', value: "ARTIC_V3"),
+                                            string(name: 'KIT', value: "none"),
                                             string(name: 'K8S_QUEUE_SIZE', value: "10"),
                                     ]
                                 )

--- a/jenkins/files/sars_cov_2/small_tests/Jenkinsfile
+++ b/jenkins/files/sars_cov_2/small_tests/Jenkinsfile
@@ -148,7 +148,7 @@ pipeline {
                                         string(name: 'NXF_WORK', value: "/data/work/unknown_short"),
                                         string(name: 'ANALYSIS_RUN', value: "unknown_short"),
                                         string(name: 'SEQUENCING_TECHNOLOGY', value: "unknown"),
-                                        string(name: 'KIT', value: "ARTIC_V3"),
+                                        string(name: 'KIT', value: "none"),
                                 ]
                             )
                         }

--- a/jenkins/files/sars_cov_2/validation-ci/Jenkinsfile
+++ b/jenkins/files/sars_cov_2/validation-ci/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
                                             string(name: 'NXF_WORK', value: "/data/work/unknown"),
                                             string(name: 'ANALYSIS_RUN', value: "unknown"),
                                             string(name: 'SEQUENCING_TECHNOLOGY', value: "unknown"),
-                                            string(name: 'KIT', value: "ARTIC_V3"),
+                                            string(name: 'KIT', value: "none"),
                                     ]
                                 )
                             }

--- a/psga/sars_cov_2/psga.nf
+++ b/psga/sars_cov_2/psga.nf
@@ -36,20 +36,32 @@ if( "[:]" in [
 }
 
 
-/* Store primers in ncov dockerfile with path:
- * PRIMERS (ARTIC, Midnight-IDT, Midnight-ONT, NEB-VarSkip)
- * Store primers in ncov dockerfile with path:
- * /primer_schemes/${scheme}/SARS-CoV-2/${scheme_version}
- * e.g. --kit ARTIC_V4 will use the primers stored in: /primer_schemes/ARTIC/SARS-CoV-2/V4
- */
-split_kit = params.kit.split('_')
-if ( split_kit.length != 2 ) {
-    throw new Exception("--kit must have the format: PRIMERNAME_PRIMERVERSION")
-}
-scheme = split_kit[0]
-scheme_version = split_kit[1]
+scheme = ""
+scheme_version = ""
 scheme_dir = "/primer_schemes"
 
+if ( params.sequencing_technology in ["illumina", "ont"] ) {
+
+    /* Store primers in ncov dockerfile with path:
+     * PRIMERS (ARTIC, Midnight-IDT, Midnight-ONT, NEB-VarSkip)
+     * Store primers in ncov dockerfile with path:
+     * /primer_schemes/${scheme}/SARS-CoV-2/${scheme_version}
+     * e.g. --kit ARTIC_V4 will use the primers stored in: /primer_schemes/ARTIC/SARS-CoV-2/V4
+     */
+    split_kit = params.kit.split('_')
+    if ( split_kit.length != 2 ) {
+        throw new Exception("--kit must have the format: PRIMERNAME_PRIMERVERSION for illumina/ont samples")
+    }
+    scheme = split_kit[0]
+    scheme_version = split_kit[1]
+
+} else if ( params.sequencing_technology == "unknown" ) {
+
+    if ( params.kit != "none" ) {
+        throw new Exception("--kit must be 'none' for FASTA samples")
+    }
+
+}
 
 /*
  * Main workflow for the pathogen: SARS-CoV-2.


### PR DESCRIPTION
**Changes:**
* if `--sequencing_technology` is `unknown` (=FASTA samples), then `--kit` must be `none`. In other words, primers are passed via `--kit` only for illumina / ont samples. The case where illumina/ont samples do not have any primers is not currently supported by the pipeline and is not part of this ticket.


**Tests:**
See jenkins for integration tests.
Here:
Incorrect input:
```
root@sars-cov-2-pipeline-minikube-5985485ddc-zdfkk:/app/psga# nextflow run . --run unknown_short --sequencing_technology unknown --kit ARTIC_V3 --metadata s3://synthetic-data-dev/UKHSA/small_tests/unknown/metadata.csv --output_path /data/output/unknown_short
N E X T F L O W  ~  version 22.08.0-edge
Launching `./main.nf` [elated_hypatia] DSL2 - revision: b450160779
--kit must be 'none' for FASTA samples

 -- Check script './psga.nf' at line: 61 or see '.nextflow.log' file for more details
```

```
root@sars-cov-2-pipeline-minikube-5985485ddc-zdfkk:/app/psga# nextflow run . --run illumina_short --sequencing_technology illumina --kit none --metadata s3://synthetic-data-dev/UKHSA/small_tests/illumina/metadata.csv --output_path /data/output/illumina_short
N E X T F L O W  ~  version 22.08.0-edge
Launching `./main.nf` [drunk_easley] DSL2 - revision: b450160779
--kit must have the format: PRIMERNAME_PRIMERVERSION for illumina/ont samples

 -- Check script './psga.nf' at line: 53 or see '.nextflow.log' file for more details
```
Correct input:
```
root@sars-cov-2-pipeline-minikube-5985485ddc-zdfkk:/app/psga# nextflow run . --run unknown_short --sequencing_technology unknown --kit none --metadata s3://synthetic-data-dev/UKHSA/small_tests/unknown/metadata.csv --output_path /data/output/unknown_short
N E X T F L O W  ~  version 22.08.0-edge
Launching `./main.nf` [focused_aryabhata] DSL2 - revision: b450160779
[b8/0edefd] Submitted process > psga:pipeline_start
[0f/6b52d8] Submitted process > psga:check_metadata (metadata.csv)
[ef/7ad755] Submitted process > psga:stage_sample_file (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[ad/32b5ed] Submitted process > psga:reheader:standardise_fasta (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[d4/ff4312] Submitted process > psga:reheader:reheader_fasta (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.consensus.fa)
[f2/bdd475] Submitted process > psga:stage_sample_file (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fa)
[08/022349] Submitted process > psga:reheader:standardise_fasta (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fa)
[27/2bb81e] Submitted process > psga:reheader:reheader_fasta (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.consensus.fa)
[99/954a31] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[99/4aae78] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fasta)
[75/6c940e] Submitted process > psga:pangolin (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[5c/9cb7dd] Submitted process > psga:pangolin (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fasta)
[19/1c3e40] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[01/f379e6] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
[48/b76707] Submitted process > pipeline_end
```
```
root@sars-cov-2-pipeline-minikube-5985485ddc-zdfkk:/app/psga# nextflow run . --run ont_short --sequencing_technology ont --kit ARTIC_V3 --metadata s3://synthetic-data-dev/UKHSA/small_tests/ont/metadata.csv --output_path /data/output/ont_short
N E X T F L O W  ~  version 22.08.0-edge
Launching `./main.nf` [magical_goodall] DSL2 - revision: b450160779
[74/710038] Submitted process > psga:pipeline_start
[36/a2ef52] Submitted process > psga:check_metadata (metadata.csv)
[75/10c89f] Submitted process > psga:stage_fastq_sample_file (2 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[aa/7e6952] Submitted process > psga:contamination_removal (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[8c/a4a708] Submitted process > psga:stage_sample_file (1 - d3e958b5-0c56-48d6-807b-6a89f61408ce.bam)
[9e/1428c2] Submitted process > psga:bam_to_fastq (1 - d3e958b5-0c56-48d6-807b-6a89f61408ce.bam)
[44/ccdb2f] Submitted process > psga:stage_fastq_sample_file (1 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fq.gz)
[c2/8d277b] Submitted process > psga:contamination_removal (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fq.gz)
[69/3142d2] Submitted process > psga:contamination_removal (3 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fastq)
[c8/0e58ca] Submitted process > psga:fastqc (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz)
[79/49ac2c] Submitted process > psga:fastqc (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq.gz)
[ee/d7b035] Submitted process > psga:fastqc (3 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fastq.gz)
[52/e6ef41] Submitted process > psga:ncov2019_artic (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz)
[4b/f64994] Submitted process > psga:ncov2019_artic (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq.gz)
[60/120813] Submitted process > psga:ncov2019_artic (3 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fastq.gz)
[8c/6c43b7] Submitted process > psga:reheader:reheader_fasta (1 - [b833399a-4d49-4d00-abdb-39d5086a5a0d.qc.csv, b833399a-4d49-4d00-abdb-39d5086a5a0d.consensus.fa])
[6a/767e50] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[05/182466] Submitted process > psga:pangolin (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[2d/498d41] Submitted process > psga:reheader:reheader_fasta (2 - [d3e958b5-0c56-48d6-807b-6a89f61408ce.qc.csv, d3e958b5-0c56-48d6-807b-6a89f61408ce.consensus.fa])
[d2/ff98bd] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (2 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fasta)
[a4/def9c0] Submitted process > psga:pangolin (2 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fasta)
[ad/c82e2f] Submitted process > psga:reheader:reheader_fasta (3 - [2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.qc.csv, 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.consensus.fa])
[ec/1b6344] Submitted process > psga:submit_analysis_run_results:submit_ncov_results
[6c/c6a9bf] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (3 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fasta)
[a3/28cbe0] Submitted process > psga:pangolin (3 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fasta)
[85/e1f03b] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[6f/10e158] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
[73/f53b71] Submitted process > pipeline_end
```
```
root@sars-cov-2-pipeline-minikube-5985485ddc-zdfkk:/app/psga# nextflow run . --run illumina_short --sequencing_technology illumina --kit ARTIC_V3 --metadata s3://synthetic-data-dev/UKHSA/small_tests/illumina/metadata.csv --output_path /data/output/illumina_short
N E X T F L O W  ~  version 22.08.0-edge
Launching `./main.nf` [trusting_minsky] DSL2 - revision: b450160779
[cc/b9cbfd] Submitted process > psga:pipeline_start
[01/6c7c66] Submitted process > psga:check_metadata (metadata.csv)
[0a/e822ec] Submitted process > psga:stage_fastq_sample_file (2 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fq, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fq])
[9f/adfad4] Submitted process > psga:stage_sample_file (1 - 0c0b5622-d63a-42cc-a804-13d71e1a5306.bam)
[c4/1bb242] Submitted process > psga:contamination_removal (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fq, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fq])
[eb/a2305c] Submitted process > psga:bam_to_fastq (1 - 0c0b5622-d63a-42cc-a804-13d71e1a5306.bam)
[6a/e01c25] Submitted process > psga:stage_fastq_sample_file (1 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[14/bcb77c] Submitted process > psga:contamination_removal (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[c8/a15ece] Submitted process > psga:stage_sample_file (2 - 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.bam)
[3a/9c0862] Submitted process > psga:bam_to_fastq (2 - 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.bam)
[86/f81503] Submitted process > psga:fastqc (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fastq.gz, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fastq.gz])
[1a/646887] Submitted process > psga:contamination_removal (3 - [0c0b5622-d63a-42cc-a804-13d71e1a5306_1.fastq.gz, 0c0b5622-d63a-42cc-a804-13d71e1a5306_2.fastq.gz])
[88/24a602] Submitted process > psga:fastqc (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[80/c2095b] Submitted process > psga:contamination_removal (4 - [39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_1.fastq.gz, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_2.fastq.gz])
[47/79427f] Submitted process > psga:ncov2019_artic (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fastq.gz, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fastq.gz])
[1c/2d94a6] Submitted process > psga:ncov2019_artic (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[c2/355816] Submitted process > psga:fastqc (3 - [0c0b5622-d63a-42cc-a804-13d71e1a5306_1.fastq.gz, 0c0b5622-d63a-42cc-a804-13d71e1a5306_2.fastq.gz])
[99/97e6e4] Submitted process > psga:fastqc (4 - [39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_1.fastq.gz, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_2.fastq.gz])
[c7/8d0470] Submitted process > psga:ncov2019_artic (3 - [0c0b5622-d63a-42cc-a804-13d71e1a5306_1.fastq.gz, 0c0b5622-d63a-42cc-a804-13d71e1a5306_2.fastq.gz])
[93/a5ff1f] Submitted process > psga:ncov2019_artic (4 - [39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_1.fastq.gz, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_2.fastq.gz])
[93/313815] Submitted process > psga:reheader:reheader_fasta (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a.qc.csv, aff01b7c-8a0a-40bf-927a-0548add8ea5a.primertrimmed.consensus.fa])
[d1/d3a8f5] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (1 - aff01b7c-8a0a-40bf-927a-0548add8ea5a.fasta)
[40/21f504] Submitted process > psga:pangolin (1 - aff01b7c-8a0a-40bf-927a-0548add8ea5a.fasta)
[a1/b92961] Submitted process > psga:reheader:reheader_fasta (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1.qc.csv, 9729bce7-f0a9-4617-b6e0-6145307741d1.primertrimmed.consensus.fa])
[17/913398] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (2 - 9729bce7-f0a9-4617-b6e0-6145307741d1.fasta)
[54/202dae] Submitted process > psga:pangolin (2 - 9729bce7-f0a9-4617-b6e0-6145307741d1.fasta)
[8a/7eee2e] Submitted process > psga:reheader:reheader_fasta (3 - [0c0b5622-d63a-42cc-a804-13d71e1a5306.qc.csv, 0c0b5622-d63a-42cc-a804-13d71e1a5306.primertrimmed.consensus.fa])
[11/037557] Submitted process > psga:reheader:reheader_fasta (4 - [39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.qc.csv, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.primertrimmed.consensus.fa])
[6a/2db46b] Submitted process > psga:submit_analysis_run_results:submit_ncov_results
[5d/3b04f0] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (3 - 0c0b5622-d63a-42cc-a804-13d71e1a5306.fasta)
[da/fb2d1e] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (4 - 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.fasta)
[7a/611af7] Submitted process > psga:pangolin (3 - 0c0b5622-d63a-42cc-a804-13d71e1a5306.fasta)
[40/c7dd3d] Submitted process > psga:pangolin (4 - 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.fasta)
[1d/3a5b3f] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[dc/da470c] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
[22/ec4b39] Submitted process > pipeline_end
```
