### PR TITLE
PSG-922: add bam and variant files to the list of ncov2019-artic published files

### DIFF
--- a/scripts/sars_cov_2/generate_pipeline_results_files.py
+++ b/scripts/sars_cov_2/generate_pipeline_results_files.py
@@ -274,7 +274,7 @@ def get_expected_output_files_per_sample(
             contamination_removal_suffixes = [".fastq.gz"]
             fastqc_suffixes = ["fastqc.zip"]
             ncov_bam_suffixes = [".primertrimmed.rg.sorted.bam", ".primertrimmed.rg.sorted.bam.bai"]
-            ncov_fasta_suffixes = [".consensus.fa", ".muscle.in.fa", ".muscle.out.fa", ".preconsensus.fa"]
+            ncov_fasta_suffixes = [".consensus.fa", ".preconsensus.fa"]
             ncov_variants_suffixes = [".pass.vcf.gz", ".pass.vcf.gz.tbi"]
         else:
             raise ValueError(f"Unsupported sequencing_technology: {sequencing_technology}")

--- a/scripts/sars_cov_2/generate_pipeline_results_files.py
+++ b/scripts/sars_cov_2/generate_pipeline_results_files.py
@@ -267,11 +267,15 @@ def get_expected_output_files_per_sample(
         if sequencing_technology == ILLUMINA:
             contamination_removal_suffixes = [f"_{r}.fastq.gz" for r in [1, 2]]
             fastqc_suffixes = [f"{r}_fastqc.zip" for r in [1, 2]]
+            ncov_bam_suffixes = [".mapped.primertrimmed.sorted.bam"]
             ncov_fasta_suffixes = [".primertrimmed.consensus.fa"]
+            ncov_variants_suffixes = [".variants.tsv"]
         elif sequencing_technology == ONT:
             contamination_removal_suffixes = [".fastq.gz"]
             fastqc_suffixes = ["fastqc.zip"]
+            ncov_bam_suffixes = [".primertrimmed.rg.sorted.bam"]
             ncov_fasta_suffixes = [".consensus.fa", ".muscle.in.fa", ".muscle.out.fa", ".preconsensus.fa"]
+            ncov_variants_suffixes = [".pass.vcf.gz"]
         else:
             raise ValueError(f"Unsupported sequencing_technology: {sequencing_technology}")
 
@@ -289,7 +293,13 @@ def get_expected_output_files_per_sample(
         for sample_id in sample_ids_result_files.ncov_completed_samples:
             # expected files for samples which completed ncov
             output_files[sample_id].extend(
+                [output_path / "ncov2019-artic" / "output_bam" / f"{sample_id}{e}" for e in ncov_bam_suffixes]
+            )
+            output_files[sample_id].extend(
                 [output_path / "ncov2019-artic" / "output_fasta" / f"{sample_id}{e}" for e in ncov_fasta_suffixes]
+            )
+            output_files[sample_id].extend(
+                [output_path / "ncov2019-artic" / "output_variants" / f"{sample_id}{e}" for e in ncov_variants_suffixes]
             )
             output_files[sample_id].append(output_path / "ncov2019-artic" / "output_plots" / f"{sample_id}.depth.png")
 

--- a/scripts/sars_cov_2/generate_pipeline_results_files.py
+++ b/scripts/sars_cov_2/generate_pipeline_results_files.py
@@ -267,15 +267,15 @@ def get_expected_output_files_per_sample(
         if sequencing_technology == ILLUMINA:
             contamination_removal_suffixes = [f"_{r}.fastq.gz" for r in [1, 2]]
             fastqc_suffixes = [f"{r}_fastqc.zip" for r in [1, 2]]
-            ncov_bam_suffixes = [".mapped.primertrimmed.sorted.bam"]
+            ncov_bam_suffixes = [".mapped.primertrimmed.sorted.bam", ".mapped.primertrimmed.sorted.bam.bai"]
             ncov_fasta_suffixes = [".primertrimmed.consensus.fa"]
             ncov_variants_suffixes = [".variants.tsv"]
         elif sequencing_technology == ONT:
             contamination_removal_suffixes = [".fastq.gz"]
             fastqc_suffixes = ["fastqc.zip"]
-            ncov_bam_suffixes = [".primertrimmed.rg.sorted.bam"]
+            ncov_bam_suffixes = [".primertrimmed.rg.sorted.bam", ".primertrimmed.rg.sorted.bam.bai"]
             ncov_fasta_suffixes = [".consensus.fa", ".muscle.in.fa", ".muscle.out.fa", ".preconsensus.fa"]
-            ncov_variants_suffixes = [".pass.vcf.gz"]
+            ncov_variants_suffixes = [".pass.vcf.gz", ".pass.vcf.gz.tbi"]
         else:
             raise ValueError(f"Unsupported sequencing_technology: {sequencing_technology}")
 

--- a/tests/sars_cov_2/test_generate_pipeline_results_files.py
+++ b/tests/sars_cov_2/test_generate_pipeline_results_files.py
@@ -29,7 +29,6 @@ def check_sample_list(input_path, expected_samples):
     assert sorted(expected_samples) == sorted(processed_samples)
 
 
-# TODO: need a case for each sequencing technology
 @pytest.mark.parametrize(
     "metadata,ncov_csv,pangolin_csv,analysis_run_name,sequencing_technology,"
     "exp_lists,exp_results_csv,exp_resultfiles_json",
@@ -143,9 +142,6 @@ def test_generate_pipeline_results_files(
         args,
     )
 
-    # TODO remove
-    print(rv.output)
-
     assert rv.exit_code == 0
 
     expected_output_df = pd.read_csv(test_data_path / "pipeline_results_files" / exp_results_csv)
@@ -181,7 +177,11 @@ def test_generate_pipeline_results_files(
         calc_resultfiles_json_dict = json.load(json_fd)
 
     exp_result_files_json_dict_full_path = {
-        sample_id: [f"{str(tmp_path)}/{f}" for f in files] for sample_id, files in exp_resultfiles_json_dict.items()
+        sample_id: sorted([f"{str(tmp_path)}/{f}" for f in files])
+        for sample_id, files in exp_resultfiles_json_dict.items()
+    }
+    calc_result_files_json_dict_sorted = {
+        sample_id: sorted(files) for sample_id, files in calc_resultfiles_json_dict.items()
     }
 
-    assert exp_result_files_json_dict_full_path, calc_resultfiles_json_dict
+    assert exp_result_files_json_dict_full_path == calc_result_files_json_dict_sorted

--- a/tests/test_data/pipeline_results_files/resultfiles_illumina.json
+++ b/tests/test_data/pipeline_results_files/resultfiles_illumina.json
@@ -5,8 +5,11 @@
         "contamination_removal/counting/0774181d-fb20-4a73-b887-38af7eda9b38.txt",
         "fastqc/0774181d-fb20-4a73-b887-38af7eda9b38_1_fastqc.zip",
         "fastqc/0774181d-fb20-4a73-b887-38af7eda9b38_2_fastqc.zip",
+        "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.mapped.primertrimmed.sorted.bam",
+        "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.mapped.primertrimmed.sorted.bam.bai",
         "ncov2019-artic/output_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.primertrimmed.consensus.fa",
-        "ncov2019-artic/output_plots/0774181d-fb20-4a73-b887-38af7eda9b38.depth.png"
+        "ncov2019-artic/output_plots/0774181d-fb20-4a73-b887-38af7eda9b38.depth.png",
+        "ncov2019-artic/output_variants/0774181d-fb20-4a73-b887-38af7eda9b38.variants.tsv"
     ],
     "56a63f60-764d-4fc7-8764-a46023cbe324": [
         "contamination_removal/cleaned_fastq/56a63f60-764d-4fc7-8764-a46023cbe324_1.fastq.gz",
@@ -14,8 +17,11 @@
         "contamination_removal/counting/56a63f60-764d-4fc7-8764-a46023cbe324.txt",
         "fastqc/56a63f60-764d-4fc7-8764-a46023cbe324_1_fastqc.zip",
         "fastqc/56a63f60-764d-4fc7-8764-a46023cbe324_2_fastqc.zip",
+        "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.mapped.primertrimmed.sorted.bam",
+        "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.mapped.primertrimmed.sorted.bam.bai",
         "ncov2019-artic/output_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.primertrimmed.consensus.fa",
         "ncov2019-artic/output_plots/56a63f60-764d-4fc7-8764-a46023cbe324.depth.png",
+        "ncov2019-artic/output_variants/56a63f60-764d-4fc7-8764-a46023cbe324.variants.tsv",
         "reheadered-fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta"
     ],
     "985347c5-ff6a-454c-ac34-bc353d05dd70": [
@@ -31,8 +37,11 @@
         "contamination_removal/counting/a0951432-cd94-45b5-96d5-b721c037a451.txt",
         "fastqc/a0951432-cd94-45b5-96d5-b721c037a451_1_fastqc.zip",
         "fastqc/a0951432-cd94-45b5-96d5-b721c037a451_2_fastqc.zip",
+        "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.mapped.primertrimmed.sorted.bam",
+        "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.mapped.primertrimmed.sorted.bam.bai",
         "ncov2019-artic/output_fasta/a0951432-cd94-45b5-96d5-b721c037a451.primertrimmed.consensus.fa",
         "ncov2019-artic/output_plots/a0951432-cd94-45b5-96d5-b721c037a451.depth.png",
+        "ncov2019-artic/output_variants/a0951432-cd94-45b5-96d5-b721c037a451.variants.tsv",
         "reheadered-fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta"
     ],
     "e80f3c63-d139-4c14-bd72-7a43897ab40d": [
@@ -41,8 +50,11 @@
         "contamination_removal/counting/e80f3c63-d139-4c14-bd72-7a43897ab40d.txt",
         "fastqc/e80f3c63-d139-4c14-bd72-7a43897ab40d_1_fastqc.zip",
         "fastqc/e80f3c63-d139-4c14-bd72-7a43897ab40d_2_fastqc.zip",
+        "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.mapped.primertrimmed.sorted.bam",
+        "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.mapped.primertrimmed.sorted.bam.bai",
         "ncov2019-artic/output_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.primertrimmed.consensus.fa",
         "ncov2019-artic/output_plots/e80f3c63-d139-4c14-bd72-7a43897ab40d.depth.png",
+        "ncov2019-artic/output_variants/e80f3c63-d139-4c14-bd72-7a43897ab40d.variants.tsv",
         "reheadered-fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta"
     ]
 }

--- a/tests/test_data/pipeline_results_files/resultfiles_ont.json
+++ b/tests/test_data/pipeline_results_files/resultfiles_ont.json
@@ -3,21 +3,25 @@
         "contamination_removal/cleaned_fastq/0774181d-fb20-4a73-b887-38af7eda9b38.fastq.gz",
         "contamination_removal/counting/0774181d-fb20-4a73-b887-38af7eda9b38.txt",
         "fastqc/0774181d-fb20-4a73-b887-38af7eda9b38_fastqc.zip",
+        "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.primertrimmed.rg.sorted.bam",
+        "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.primertrimmed.rg.sorted.bam.bai",
         "ncov2019-artic/output_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.consensus.fa",
-        "ncov2019-artic/output_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.muscle.in.fa",
-        "ncov2019-artic/output_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.muscle.out.fa",
         "ncov2019-artic/output_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.preconsensus.fa",
-        "ncov2019-artic/output_plots/0774181d-fb20-4a73-b887-38af7eda9b38.depth.png"
+        "ncov2019-artic/output_plots/0774181d-fb20-4a73-b887-38af7eda9b38.depth.png",
+        "ncov2019-artic/output_variants/0774181d-fb20-4a73-b887-38af7eda9b38.pass.vcf.gz",
+        "ncov2019-artic/output_variants/0774181d-fb20-4a73-b887-38af7eda9b38.pass.vcf.gz.tbi"
     ],
     "56a63f60-764d-4fc7-8764-a46023cbe324": [
         "contamination_removal/cleaned_fastq/56a63f60-764d-4fc7-8764-a46023cbe324.fastq.gz",
         "contamination_removal/counting/56a63f60-764d-4fc7-8764-a46023cbe324.txt",
         "fastqc/56a63f60-764d-4fc7-8764-a46023cbe324_fastqc.zip",
+        "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.primertrimmed.rg.sorted.bam",
+        "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.primertrimmed.rg.sorted.bam.bai",
         "ncov2019-artic/output_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.consensus.fa",
-        "ncov2019-artic/output_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.muscle.in.fa",
-        "ncov2019-artic/output_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.muscle.out.fa",
         "ncov2019-artic/output_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.preconsensus.fa",
         "ncov2019-artic/output_plots/56a63f60-764d-4fc7-8764-a46023cbe324.depth.png",
+        "ncov2019-artic/output_variants/56a63f60-764d-4fc7-8764-a46023cbe324.pass.vcf.gz",
+        "ncov2019-artic/output_variants/56a63f60-764d-4fc7-8764-a46023cbe324.pass.vcf.gz.tbi",
         "reheadered-fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta"
     ],
     "985347c5-ff6a-454c-ac34-bc353d05dd70": [
@@ -29,22 +33,26 @@
         "contamination_removal/cleaned_fastq/a0951432-cd94-45b5-96d5-b721c037a451.fastq.gz",
         "contamination_removal/counting/a0951432-cd94-45b5-96d5-b721c037a451.txt",
         "fastqc/a0951432-cd94-45b5-96d5-b721c037a451_fastqc.zip",
+        "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.primertrimmed.rg.sorted.bam",
+        "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.primertrimmed.rg.sorted.bam.bai",
         "ncov2019-artic/output_fasta/a0951432-cd94-45b5-96d5-b721c037a451.consensus.fa",
-        "ncov2019-artic/output_fasta/a0951432-cd94-45b5-96d5-b721c037a451.muscle.in.fa",
-        "ncov2019-artic/output_fasta/a0951432-cd94-45b5-96d5-b721c037a451.muscle.out.fa",
         "ncov2019-artic/output_fasta/a0951432-cd94-45b5-96d5-b721c037a451.preconsensus.fa",
         "ncov2019-artic/output_plots/a0951432-cd94-45b5-96d5-b721c037a451.depth.png",
+        "ncov2019-artic/output_variants/a0951432-cd94-45b5-96d5-b721c037a451.pass.vcf.gz",
+        "ncov2019-artic/output_variants/a0951432-cd94-45b5-96d5-b721c037a451.pass.vcf.gz.tbi",
         "reheadered-fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta"
     ],
     "e80f3c63-d139-4c14-bd72-7a43897ab40d": [
         "contamination_removal/cleaned_fastq/e80f3c63-d139-4c14-bd72-7a43897ab40d.fastq.gz",
         "contamination_removal/counting/e80f3c63-d139-4c14-bd72-7a43897ab40d.txt",
         "fastqc/e80f3c63-d139-4c14-bd72-7a43897ab40d_fastqc.zip",
+        "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.primertrimmed.rg.sorted.bam",
+        "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.primertrimmed.rg.sorted.bam.bai",
         "ncov2019-artic/output_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.consensus.fa",
-        "ncov2019-artic/output_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.muscle.in.fa",
-        "ncov2019-artic/output_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.muscle.out.fa",
         "ncov2019-artic/output_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.preconsensus.fa",
         "ncov2019-artic/output_plots/e80f3c63-d139-4c14-bd72-7a43897ab40d.depth.png",
+        "ncov2019-artic/output_variants/e80f3c63-d139-4c14-bd72-7a43897ab40d.pass.vcf.gz",
+        "ncov2019-artic/output_variants/e80f3c63-d139-4c14-bd72-7a43897ab40d.pass.vcf.gz.tbi",
         "reheadered-fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta"
     ]
 }


### PR DESCRIPTION
**Changes:**
* add extra output generated by ncov. In particular:
a. collect primertrimmed.rg.sorted.bam and pass.vcf.gz for ont samples
b. collect mapped.primertrimmed.sorted.bam and variants.tsv for illumina samples
* remove `muscle.in.fa` and `muscle.out.fa` as these files are no longer generated following the update of the medaka model

This PR also fixes the integration tests: https://jenkins.services.congenica.net/job/psga-pipeline-sars-cov-2-small-tests/job/PSG-922_add_additional_output_files/5 

**Testing:**
```
root@sars-cov-2-pipeline-minikube-5985485ddc-zdfkk:/app/psga# nextflow run . --run ont_short --sequencing_technology ont --kit ARTIC_V3 --metadata /data/ont.csv --output_path /data/output/ont_short -resume
N E X T F L O W  ~  version 22.08.0-edge
Launching `./main.nf` [angry_koch] DSL2 - revision: b450160779
[83/283366] Cached process > psga:pipeline_start
[6b/b7268a] Cached process > psga:check_metadata (ont.csv)
[01/851802] Cached process > psga:stage_fastq_sample_file (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[11/63ba77] Cached process > psga:contamination_removal (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[75/093e8a] Cached process > psga:fastqc (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz)
[32/a2164c] Submitted process > psga:ncov2019_artic (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz)
[8e/87e15f] Submitted process > psga:submit_analysis_run_results:submit_ncov_results
[b2/26a0d8] Submitted process > psga:reheader:reheader_fasta (1 - [b833399a-4d49-4d00-abdb-39d5086a5a0d.qc.csv, b833399a-4d49-4d00-abdb-39d5086a5a0d.consensus.fa])
[cc/e46758] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[63/cee0af] Submitted process > psga:pangolin (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[83/2756ff] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[35/96265a] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
[45/68b716] Submitted process > pipeline_end

root@sars-cov-2-pipeline-minikube-5985485ddc-zdfkk:/app/psga# ls -lart /data/output/ont_short/ncov2019-artic/**/*
-rw-r--r-- 1 root root    29916 Sep  8 15:45 /data/output/ont_short/ncov2019-artic/output_fasta/b833399a-4d49-4d00-abdb-39d5086a5a0d.preconsensus.fa
-rw-r--r-- 1 root root    30445 Sep  8 15:45 /data/output/ont_short/ncov2019-artic/output_fasta/b833399a-4d49-4d00-abdb-39d5086a5a0d.consensus.fa
-rw-r--r-- 1 root root      126 Sep  8 15:45 /data/output/ont_short/ncov2019-artic/output_variants/b833399a-4d49-4d00-abdb-39d5086a5a0d.pass.vcf.gz.tbi
-rw-r--r-- 1 root root     1465 Sep  8 15:45 /data/output/ont_short/ncov2019-artic/output_variants/b833399a-4d49-4d00-abdb-39d5086a5a0d.pass.vcf.gz
-rw-r--r-- 1 root root    39389 Sep  8 15:45 /data/output/ont_short/ncov2019-artic/output_plots/b833399a-4d49-4d00-abdb-39d5086a5a0d.depth.png
-rw-r--r-- 1 root root      152 Sep  8 15:45 /data/output/ont_short/ncov2019-artic/output_bam/b833399a-4d49-4d00-abdb-39d5086a5a0d.primertrimmed.rg.sorted.bam.bai
-rw-r--r-- 1 root root 15789029 Sep  8 15:45 /data/output/ont_short/ncov2019-artic/output_bam/b833399a-4d49-4d00-abdb-39d5086a5a0d.primertrimmed.rg.sorted.bam
```

Illumina:
```
root@sars-cov-2-pipeline-minikube-5985485ddc-zdfkk:/app/psga# nextflow run . --run illumina_short --sequencing_technology illumina --kit ARTIC_V3 --metadata /data/illumina.csv --output_path /data/output/illumina_short
N E X T F L O W  ~  version 22.08.0-edge
Launching `./main.nf` [sad_koch] DSL2 - revision: b450160779
[3a/32a447] Submitted process > psga:pipeline_start
[ac/142cd2] Submitted process > psga:check_metadata (illumina.csv)
[2a/9fbecf] Submitted process > psga:stage_fastq_sample_file (1 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[35/82b659] Submitted process > psga:contamination_removal (1 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[d9/cbe04a] Submitted process > psga:fastqc (1 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[03/6b709b] Submitted process > psga:ncov2019_artic (1 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[25/a7266c] Submitted process > psga:reheader:reheader_fasta (1 - [9729bce7-f0a9-4617-b6e0-6145307741d1.qc.csv, 9729bce7-f0a9-4617-b6e0-6145307741d1.primertrimmed.consensus.fa])
[a8/21a30d] Submitted process > psga:submit_analysis_run_results:submit_ncov_results
[ee/99e7f6] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (1 - 9729bce7-f0a9-4617-b6e0-6145307741d1.fasta)
[72/a6016a] Submitted process > psga:pangolin (1 - 9729bce7-f0a9-4617-b6e0-6145307741d1.fasta)
[c5/a5d66f] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[8c/38fc5c] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
[0f/37d2dd] Submitted process > pipeline_end



root@sars-cov-2-pipeline-minikube-5985485ddc-zdfkk:/app/psga# ls -lart /data/output/illumina_short/ncov2019-artic/**/*
-rw-r--r-- 1 root root     3237 Sep  8 15:48 /data/output/illumina_short/ncov2019-artic/output_variants/9729bce7-f0a9-4617-b6e0-6145307741d1.variants.tsv
-rw-r--r-- 1 root root    44761 Sep  8 15:48 /data/output/illumina_short/ncov2019-artic/output_plots/9729bce7-f0a9-4617-b6e0-6145307741d1.depth.png
-rw-r--r-- 1 root root    29989 Sep  8 15:48 /data/output/illumina_short/ncov2019-artic/output_fasta/9729bce7-f0a9-4617-b6e0-6145307741d1.primertrimmed.consensus.fa
-rw-r--r-- 1 root root      152 Sep  8 15:48 /data/output/illumina_short/ncov2019-artic/output_bam/9729bce7-f0a9-4617-b6e0-6145307741d1.mapped.primertrimmed.sorted.bam.bai
-rw-r--r-- 1 root root 12492925 Sep  8 15:48 /data/output/illumina_short/ncov2019-artic/output_bam/9729bce7-f0a9-4617-b6e0-6145307741d1.mapped.primertrimmed.sorted.bam
```