### PR TITLE
PSG-1026: enable configuration of name for sars-cov-2 main docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ base-images:
 
 # build images per pathogen
 sars-cov-2-images:
-	docker build --build-arg pathogen=sars_cov_2 -t ${DOCKER_IMAGE_PREFIX}/psga-pipeline:${SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG} -f docker/Dockerfile.psga-pipeline .
+	docker build --build-arg pathogen=sars_cov_2 -t ${DOCKER_IMAGE_PREFIX}/sars-cov-2-pipeline:${SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG} -f docker/Dockerfile.psga-pipeline .
 	docker build -t ${DOCKER_IMAGE_PREFIX}/ncov2019-artic-nf-illumina:${NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG} -f docker/Dockerfile.ncov2019-artic-nf-illumina .
 	docker build -t ${DOCKER_IMAGE_PREFIX}/ncov2019-artic-nf-nanopore:${NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG} -f docker/Dockerfile.ncov2019-artic-nf-nanopore .
 	docker build -t ${DOCKER_IMAGE_PREFIX}/pangolin:${PANGOLIN_DOCKER_IMAGE_TAG} -f docker/Dockerfile.pangolin .

--- a/jenkins/files/sars_cov_2/Jenkinsfile
+++ b/jenkins/files/sars_cov_2/Jenkinsfile
@@ -61,6 +61,7 @@ pipeline {
 
         string(name: 'PSGA_MAX_ATTEMPTS', defaultValue: '3', description: 'The maximum number of attempts resuming a failed pipeline')
         string(name: 'PSGA_SLEEP_TIME_BETWEEN_ATTEMPTS', defaultValue: '60', description: 'The sleep time between attempts')
+        string(name: 'SARS_COV_2_PIPELINE_DOCKER_IMAGE', defaultValue: 'psga-pipeline', description: 'The name of the main docker image. This is temporary until we detach from Congenica ECR and Congenica Jenkins account')
         string(name: 'DOCKER_IMAGE_PREFIX', defaultValue: '144563655722.dkr.ecr.eu-west-1.amazonaws.com/congenica/dev', description: 'The docker image prefix to use')
         string(name: 'K8S_NODE', defaultValue: 'farmNode', description: 'The Kubernetes node to use as a nodeAffinity for worker jobs')
         string(name: 'K8S_PULL_POLICY', defaultValue: 'Always', description: 'The Kubernetes pull policy for docker images')
@@ -98,7 +99,7 @@ spec:
             - "true"
   containers:
   - name: sars-cov-2
-    image: ${params.DOCKER_IMAGE_PREFIX}/psga-pipeline:${getDockerTagFromBranch()}
+    image: ${params.DOCKER_IMAGE_PREFIX}/${params.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${getDockerTagFromBranch()}
     imagePullPolicy: ${params.K8S_PULL_POLICY}
     command:
     - "sleep"
@@ -134,6 +135,7 @@ spec:
         }
     }
     environment {
+        SARS_COV_2_PIPELINE_DOCKER_IMAGE            = "${params.SARS_COV_2_PIPELINE_DOCKER_IMAGE}"
         SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG        = "${getDockerTagFromBranch()}"
         NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG = "${getDockerTagFromBranch()}"
         NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG = "${getDockerTagFromBranch()}"

--- a/k8s/k8s_sars_cov_2.yaml
+++ b/k8s/k8s_sars_cov_2.yaml
@@ -49,6 +49,8 @@ spec:
           value: '60'
         - name: DOCKER_IMAGE_PREFIX
           value: '566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev'
+        - name: SARS_COV_2_PIPELINE_DOCKER_IMAGE
+          value: 'sars-cov-2-pipeline'
         - name: SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG
           value: 'dev_latest'
         - name: NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG

--- a/minikube/deploy_sars_cov_2.yaml
+++ b/minikube/deploy_sars_cov_2.yaml
@@ -23,7 +23,7 @@ spec:
                 values:
                 - "true"
       containers:
-      - image: 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev/psga-pipeline:1.0.0
+      - image: 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev/sars-cov-2-pipeline:1.0.0
         name: sars-cov-2-pipeline-minikube
         command:
         - python
@@ -41,6 +41,8 @@ spec:
           value: '60'
         - name: DOCKER_IMAGE_PREFIX
           value: '566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev'
+        - name: SARS_COV_2_PIPELINE_DOCKER_IMAGE
+          value: 'sars-cov-2-pipeline'
         - name: SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG
           value: '1.0.0'
         - name: NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG

--- a/psga/sars_cov_2/help.nf
+++ b/psga/sars_cov_2/help.nf
@@ -4,6 +4,7 @@ def printPathogenConfig() {
         SARS-CoV-2 pathogen
         ===================
         Environment variables:
+        * SARS_COV_2_PIPELINE_DOCKER_IMAGE            : ${SARS_COV_2_PIPELINE_DOCKER_IMAGE}
         * SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG        : ${SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}
         * NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG : ${NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG}
         * NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG : ${NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG}
@@ -24,6 +25,8 @@ def printPathogenHelp() {
         nextflow run . --run [analysis_run] --sequencing_technology [sequencing_technology] [workflow-options]
 
       Mandatory environment variables:
+        SARS_COV_2_PIPELINE_DOCKER_IMAGE
+                                The name of the sars-cov-2 docker image
         SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG
                                 The tag of the sars-cov-2 docker image
         NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG

--- a/psga/sars_cov_2/nextflow.config
+++ b/psga/sars_cov_2/nextflow.config
@@ -12,7 +12,13 @@ manifest {
 }
 
 env {
-    // docker image config
+    // enable configuration of the name for the main docker image
+    // this is needed only because the images are currently pushed on both Congenica ECR and psga-dev ECR.
+    // In congenica ECR, the image is registered as psga-pipeline, whereas in psga-dev is registered as sars-cov-2-pipeline.
+    // sars-cov-2-pipeline is the correct name and when we detach from Congenica ECR completely, this configuration can be removed.
+    SARS_COV_2_PIPELINE_DOCKER_IMAGE = "${SARS_COV_2_PIPELINE_DOCKER_IMAGE}"
+
+    // docker image tag config
     SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG = "${SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
     NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG = "${NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG}"
     NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG = "${NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG}"
@@ -50,12 +56,12 @@ process {
 
     withName:check_metadata {
         executor = 'k8s'
-        container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
+        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
     }
 
     withName:fastqc {
         executor = 'k8s'
-        container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
+        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
         errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
     }
 
@@ -69,7 +75,7 @@ process {
 
         withName:contamination_removal_illumina {
             executor = 'k8s'
-            container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
+            container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
             errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
         }
 
@@ -93,7 +99,7 @@ process {
 
         withName:contamination_removal_ont {
             executor = 'k8s'
-            container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
+            container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
             errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
         }
 
@@ -109,19 +115,19 @@ process {
 
     withName:reheader_fasta {
         executor = 'k8s'
-        container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
+        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
         memory = { "${env.K8S_PROCESS_MEMORY_MEDIUM}" as int * 1.MB * task.attempt }
         errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.K8S_PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
     }
 
     withName:store_reheadered_qc_passed_fasta {
         executor = 'k8s'
-        container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
+        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
     }
 
     withName:store_reheadered_qc_failed_fasta {
         executor = 'k8s'
-        container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
+        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
     }
 
     withName:pangolin_pipeline {
@@ -134,15 +140,15 @@ process {
 
     withName:submit_ncov_results {
         executor = 'k8s'
-        container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
+        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
     }
     withName:submit_pangolin_results {
         executor = 'k8s'
-        container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
+        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
     }
     withName:submit_pipeline_results_files {
         executor = 'k8s'
-        container = "${env.DOCKER_IMAGE_PREFIX}/psga-pipeline:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
+        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
     }
 
 }

--- a/psga/sars_cov_2/psga.nf
+++ b/psga/sars_cov_2/psga.nf
@@ -27,6 +27,7 @@ include { submit_analysis_run_results } from './submit_analysis_run_results.nf'
 
 // Required environment variables
 if( "[:]" in [
+    SARS_COV_2_PIPELINE_DOCKER_IMAGE,
     SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG,
     NCOV2019_ARTIC_NF_ILLUMINA_DOCKER_IMAGE_TAG,
     NCOV2019_ARTIC_NF_NANOPORE_DOCKER_IMAGE_TAG,


### PR DESCRIPTION
Changes:
* Add new env variable to set up the main pipeline docker image. This env variable is called SARS_COV_2_PIPELINE_DOCKER_IMAGE.


Testing:
* The use of `SARS_COV_2_PIPELINE_DOCKER_IMAGE="sars-cov-2-pipeline"` was tested on minikube. This is the setting for PSGA dev
* The use of `SARS_COV_2_PIPELINE_DOCKER_IMAGE="psga-pipeline"` was tested on Jenkins (congenica account). This is the setting for Congenica ECR / Jenkins 


Testing on Minikube:
```
(venv-psga-pipeline) pierodallepezze@CONGENICA-0256:~/psga-pipeline/minikube$ k exec -it sars-cov-2-pipeline-minikube-86db564bc9-grkz5 -- bash 
root@sars-cov-2-pipeline-minikube-86db564bc9-grkz5:/app/psga# env | grep "SARS_COV_2_PIPELINE_DOCKER_IMAGE"
SARS_COV_2_PIPELINE_DOCKER_IMAGE=sars-cov-2-pipeline

root@sars-cov-2-pipeline-minikube-86db564bc9-grkz5:/app/psga# cat nextflow.config | grep -B2 "SARS_COV_2_PIPELINE_DOCKER_IMAGE"
    // In congenica ECR, the image is registered as psga-pipeline, whereas in psga-dev is registered as sars-cov-2-pipeline.
    // sars-cov-2-pipeline is the correct name and when we detach from Congenica ECR completely, this configuration can be removed.
    SARS_COV_2_PIPELINE_DOCKER_IMAGE = "${SARS_COV_2_PIPELINE_DOCKER_IMAGE}"

    // docker image tag config
    SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG = "${SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
--
    withName:check_metadata {
        executor = 'k8s'
        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
--
    withName:fastqc {
        executor = 'k8s'
        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
--
        withName:contamination_removal_illumina {
            executor = 'k8s'
            container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
--
        withName:contamination_removal_ont {
            executor = 'k8s'
            container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
--
    withName:reheader_fasta {
        executor = 'k8s'
        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
--
    withName:store_reheadered_qc_passed_fasta {
        executor = 'k8s'
        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
--
    withName:store_reheadered_qc_failed_fasta {
        executor = 'k8s'
        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
--
    withName:submit_ncov_results {
        executor = 'k8s'
        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
--
    withName:submit_pangolin_results {
        executor = 'k8s'
        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"
--
    withName:submit_pipeline_results_files {
        executor = 'k8s'
        container = "${env.DOCKER_IMAGE_PREFIX}/${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE}:${env.SARS_COV_2_PIPELINE_DOCKER_IMAGE_TAG}"


root@sars-cov-2-pipeline-minikube-86db564bc9-grkz5:/app/psga# nextflow run . --run unknown_short --sequencing_technology unknown --kit none --metadata s3://synthetic-data-dev/UKHSA/small_tests/unknown/metadata.csv --output_path /data/output/unknown_short
N E X T F L O W  ~  version 22.08.0-edge
Launching `./main.nf` [extravagant_cuvier] DSL2 - revision: b450160779
[a3/d51129] Submitted process > psga:pipeline_start
[c8/f90d41] Submitted process > psga:check_metadata (metadata.csv)
[b2/964f65] Submitted process > psga:stage_sample_file (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fa)
[ba/54a9bf] Submitted process > psga:reheader:standardise_fasta (1 - 1a55b645-5cce-400d-b668-e281a95b4c72.fa)
[4a/afb292] Submitted process > psga:reheader:reheader_fasta (1 - 1a55b645-5cce-400d-b668-e281a95b4c72.consensus.fa)
[a6/2dc373] Submitted process > psga:stage_sample_file (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[2a/fd60c4] Submitted process > psga:reheader:standardise_fasta (2 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[1b/aed125] Submitted process > psga:reheader:reheader_fasta (2 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.consensus.fa)
[af/c95e19] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (1 - 1a55b645-5cce-400d-b668-e281a95b4c72.fasta)
[d5/1e5fec] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (2 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[bb/6e8842] Submitted process > psga:pangolin (1 - 1a55b645-5cce-400d-b668-e281a95b4c72.fasta)
[b8/25a5ad] Submitted process > psga:pangolin (2 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[c6/1637c3] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[01/29e6fe] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
[97/dc3600] Submitted process > pipeline_end
```