### PR TITLE
PSG-1097: replace Path with str in the generation of resultfiles.json so that we can process both FS paths and S3 URIs

### DIFF
--- a/jenkins/compare.py
+++ b/jenkins/compare.py
@@ -106,7 +106,7 @@ def compare_merged_output_file(
     return sample_names
 
 
-def compare_output_files_set(calc_output_files: Set[Path], exp_output_files: Set[Path]) -> None:
+def compare_output_files_set(calc_output_files: Set[str], exp_output_files: Set[str]) -> None:
     """
     Compare the expected set of output files against the actual set of output files.
     """

--- a/jenkins/files/sars_cov_2/Jenkinsfile
+++ b/jenkins/files/sars_cov_2/Jenkinsfile
@@ -196,7 +196,7 @@ spec:
                         // fetch the expected output from s3
                         sh 'aws s3 cp s3://synthetic-data-dev/UKHSA/integration_tests_expected_output/sars_cov_2/${ANALYSIS_RUN}/pipeline_output.csv ${PSGA_ROOT_PATH}/jenkins/expected_results.csv'
                         // run validations
-                        sh 'cd ${PSGA_ROOT_PATH}/jenkins && pytest  --expected-results-csv ${PSGA_ROOT_PATH}/jenkins/expected_results.csv --results-csv ${OUTPUT_PATH}/results.csv --output-path ${OUTPUT_PATH} --pathogen sars_cov_2 --sequencing-technology ${SEQUENCING_TECHNOLOGY} test_validation.py && cd -'
+                        sh 'cd ${PSGA_ROOT_PATH}/jenkins && pytest test_validation.py --expected-results-csv ${PSGA_ROOT_PATH}/jenkins/expected_results.csv --results-csv ${OUTPUT_PATH}/results.csv --output-path ${OUTPUT_PATH} --pathogen sars_cov_2 --sequencing-technology ${SEQUENCING_TECHNOLOGY} && cd -'
                     }
 
                     // copy main log, nxf work dir logs and reports to OUTPUT_PATH

--- a/jenkins/loading.py
+++ b/jenkins/loading.py
@@ -39,14 +39,14 @@ def load_data_from_csv(config: Dict, csv_path: Path) -> pd.DataFrame:
     return _refine_df(config, df)
 
 
-def get_file_paths(root: Path) -> List[Path]:
+def get_file_paths(root: Path) -> List[str]:
     """
     Return a list of file paths in root. The search is recursive.
     """
     file_list = []
     for x in root.iterdir():
         if x.is_file():
-            file_list.append(x)
+            file_list.append(str(x))
         elif x.is_dir():
             file_list.extend(get_file_paths(x))
     return file_list

--- a/jenkins/sars_cov_2.py
+++ b/jenkins/sars_cov_2.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from os.path import join as join_path  # used to join FS paths and S3 URIs
 from typing import List
 import click
 
@@ -13,7 +14,7 @@ from scripts.util.metadata import UNKNOWN
 logger = get_structlog_logger()
 
 
-def get_expected_output_files(output_path: Path, sample_ids: List[str], sequencing_technology: str) -> List[Path]:
+def get_expected_output_files(output_path: str, sample_ids: List[str], sequencing_technology: str) -> List[str]:
     """
     Return a list of ALL expected output paths
     """
@@ -34,7 +35,7 @@ def get_expected_output_files(output_path: Path, sample_ids: List[str], sequenci
     output_files = [path for sample_paths in output_files_per_sample.values() for path in sample_paths]
 
     output_files.extend(
-        [output_path / "logs" / f for f in ["check_metadata.log", "generate_pipeline_results_files.log"]]
+        [join_path(output_path, "logs", f) for f in ["check_metadata.log", "generate_pipeline_results_files.log"]]
     )
 
     notification_files = [
@@ -53,12 +54,12 @@ def get_expected_output_files(output_path: Path, sample_ids: List[str], sequenci
                 "samples_unknown_ncov_qc.txt",
             ]
         )
-        output_files.append(output_path / "ncov2019-artic" / "ncov_qc.csv")
+        output_files.append(join_path(output_path, "ncov2019-artic", "ncov_qc.csv"))
 
-    output_files.append(output_path / "pangolin" / "all_lineages_report.csv")
-    output_files.extend([output_path / "notifications" / p for p in notification_files])
-    output_files.append(output_path / "results.csv")
-    output_files.append(output_path / "resultfiles.json")
+    output_files.append(join_path(output_path, "pangolin", "all_lineages_report.csv"))
+    output_files.extend([join_path(output_path, "notifications", p) for p in notification_files])
+    output_files.append(join_path(output_path, "results.csv"))
+    output_files.append(join_path(output_path, "resultfiles.json"))
 
     return output_files
 
@@ -88,6 +89,6 @@ def sars_cov_2(ctx, sequencing_technology: str):
 
     logger.info("Validation of output files set STARTED")
     exp_output_files = get_expected_output_files(output_path, sample_ids, sequencing_technology)
-    calc_output_files = get_file_paths(output_path)
+    calc_output_files = get_file_paths(Path(output_path))
     compare_output_files_set(set(calc_output_files), set(exp_output_files))
     logger.info("Validation PASSED")

--- a/jenkins/test_validation.py
+++ b/jenkins/test_validation.py
@@ -3,8 +3,8 @@ from click.testing import CliRunner
 from jenkins.validation import validate
 
 # call:
-# pytest --results-csv results.csv --expected-results-csv results2.csv \
-#        --output-path /tmp --pathogen sars_cov_2 --sequencing-technology ont test_validation.py
+# pytest test_validation.py --results-csv results.csv --expected-results-csv results2.csv \
+#        --output-path /tmp --pathogen sars_cov_2 --sequencing-technology ont
 
 
 def test_validation(results_csv, expected_results_csv, pathogen, output_path, sequencing_technology):

--- a/jenkins/validation.py
+++ b/jenkins/validation.py
@@ -36,7 +36,7 @@ def validate(ctx, results_csv, expected_results_csv, output_path):
 
     ctx.obj["results_csv"] = Path(results_csv)
     ctx.obj["expected_results_csv"] = Path(expected_results_csv)
-    ctx.obj["output_path"] = Path(output_path)
+    ctx.obj["output_path"] = output_path  # leave this as a string as it can be FS path or S3 uri
 
 
 validate.add_command(sars_cov_2)

--- a/minikube/cleanup.sh
+++ b/minikube/cleanup.sh
@@ -2,6 +2,7 @@
 
 ## delete any nf pod
 kubectl get pods -n psga-minikube --no-headers=true | awk '/nf/{print $1}'| xargs  kubectl delete -n psga-minikube pod
+kubectl get jobs -n psga-minikube --no-headers=true | awk '/nf/{print $1}'| xargs  kubectl delete -n psga-minikube job
 
 ## delete psga-minikube
 kubectl delete deployment sars-cov-2-pipeline-minikube

--- a/tests/jenkins/test_loading.py
+++ b/tests/jenkins/test_loading.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 import pandas as pd
@@ -86,7 +87,7 @@ def test_load_data_from_csv(tmp_path, test_data_path, csv_file, config, exc):
     ],
 )
 def test_get_file_paths(tmp_path, path_list):
-    paths = [tmp_path / f for f in path_list]
+    paths = [os.path.join(tmp_path, f) for f in path_list]
     create_paths(paths)
     fetched_paths = get_file_paths(tmp_path)
     assert set(fetched_paths) == set(paths)

--- a/tests/jenkins/test_sars_cov_2_validation.py
+++ b/tests/jenkins/test_sars_cov_2_validation.py
@@ -16,7 +16,7 @@ from tests.jenkins.util import create_paths
 def create_output_files(samples: Path, root: Path, sequencing_technology: str):
     df = pd.read_csv(samples)
     sample_names = df[SAMPLE_ID].tolist()
-    paths = get_expected_output_files(root, sample_names, sequencing_technology)
+    paths = get_expected_output_files(str(root), sample_names, sequencing_technology)
     create_paths(paths)
 
 

--- a/tests/jenkins/util.py
+++ b/tests/jenkins/util.py
@@ -2,7 +2,8 @@ from pathlib import Path
 from typing import List
 
 
-def create_paths(paths: List[Path]) -> None:
-    for p in paths:
+def create_paths(paths: List[str]) -> None:
+    for path_str in paths:
+        p = Path(path_str)
         p.parent.mkdir(parents=True, exist_ok=True)
         p.touch()

--- a/tests/sars_cov_2/test_generate_pipeline_results_files.py
+++ b/tests/sars_cov_2/test_generate_pipeline_results_files.py
@@ -30,6 +30,10 @@ def check_sample_list(input_path, expected_samples):
 
 
 @pytest.mark.parametrize(
+    "use_s3_uri",
+    [False, True],
+)
+@pytest.mark.parametrize(
     "metadata,ncov_csv,pangolin_csv,analysis_run_name,sequencing_technology,"
     "exp_lists,exp_results_csv,exp_resultfiles_json",
     [
@@ -106,10 +110,13 @@ def test_generate_pipeline_results_files(
     exp_lists,
     exp_results_csv,
     exp_resultfiles_json,
+    use_s3_uri,
 ):
 
     output_csv_file = Path(tmp_path / "results.csv")
     output_json_file = Path(tmp_path / "resultfiles.json")
+
+    output_path = "s3://bucket/analysis_run" if use_s3_uri else tmp_path
 
     args = [
         "--analysis-run-name",
@@ -123,7 +130,7 @@ def test_generate_pipeline_results_files(
         "--output-json-file",
         output_json_file,
         "--output-path",
-        tmp_path,
+        output_path,
         "--sequencing-technology",
         sequencing_technology,
         "--notifications-path",
@@ -177,7 +184,7 @@ def test_generate_pipeline_results_files(
         calc_resultfiles_json_dict = json.load(json_fd)
 
     exp_result_files_json_dict_full_path = {
-        sample_id: sorted([f"{str(tmp_path)}/{f}" for f in files])
+        sample_id: sorted([f"{str(output_path)}/{f}" for f in files])
         for sample_id, files in exp_resultfiles_json_dict.items()
     }
     calc_result_files_json_dict_sorted = {


### PR DESCRIPTION
**the validation script currently fails on jenkins int test - let me fix this before reviewing**


This PR fixes the paths in the resultfiles.json (`s3:/bucket/file` -> `s3://bucket/file`).

Additional test:
```
root@sars-cov-2-pipeline-minikube-86db564bc9-sr5j5:/app/psga# nextflow run . --run ont_short --sequencing_technology ont --kit ARTIC_V3 --metadata s3://synthetic-data-dev/UKHSA/small_tests/ont/metadata.csv --output_path s3://synthetic-data-dev/UKHSA/piero_test_remove
N E X T F L O W  ~  version 22.08.0-edge
Launching `./main.nf` [deadly_mandelbrot] DSL2 - revision: b450160779
[4b/9ad1fa] Submitted process > psga:pipeline_start
[0e/78081d] Submitted process > psga:check_metadata (metadata.csv)
[02/bd67aa] Submitted process > psga:stage_sample_file (1 - d3e958b5-0c56-48d6-807b-6a89f61408ce.bam)
[aa/9eab5f] Submitted process > psga:stage_fastq_sample_file (1 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fq.gz)
[9c/42f34e] Submitted process > psga:bam_to_fastq (1 - d3e958b5-0c56-48d6-807b-6a89f61408ce.bam)
[a8/15aa1f] Submitted process > psga:stage_fastq_sample_file (2 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[4c/b86e51] Submitted process > psga:contamination_removal (1 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fq.gz)
[89/29f112] Submitted process > psga:contamination_removal (2 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[1d/fc3d31] Submitted process > psga:contamination_removal (3 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fastq)
[d1/7e7340] Submitted process > psga:fastqc (1 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq.gz)
[10/6bcd8f] Submitted process > psga:fastqc (2 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz)
[50/0f6358] Submitted process > psga:fastqc (3 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fastq.gz)
[1c/e9f6db] Submitted process > psga:ncov2019_artic (1 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq.gz)
[68/1e9892] Submitted process > psga:ncov2019_artic (2 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz)
[ae/2f2f99] Submitted process > psga:ncov2019_artic (3 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fastq.gz)
[6b/0eb338] Submitted process > psga:reheader:reheader_fasta (1 - [b833399a-4d49-4d00-abdb-39d5086a5a0d.qc.csv, b833399a-4d49-4d00-abdb-39d5086a5a0d.consensus.fa])
[25/758c9b] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[69/269d34] Submitted process > psga:pangolin (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[fb/7ddb35] Submitted process > psga:reheader:reheader_fasta (2 - [d3e958b5-0c56-48d6-807b-6a89f61408ce.qc.csv, d3e958b5-0c56-48d6-807b-6a89f61408ce.consensus.fa])
[4e/54730d] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (2 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fasta)
[59/172fcc] Submitted process > psga:pangolin (2 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fasta)
[51/c11ca1] Submitted process > psga:reheader:reheader_fasta (3 - [2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.qc.csv, 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.consensus.fa])
[21/a739dd] Submitted process > psga:submit_analysis_run_results:submit_ncov_results
[68/31cfc1] Submitted process > psga:reheader:store_reheadered_qc_passed_fasta (3 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fasta)
[9a/3213d4] Submitted process > psga:pangolin (3 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fasta)
[95/16eb15] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[45/860fcc] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
[fd/58ded0] Submitted process > pipeline_end

root@sars-cov-2-pipeline-minikube-86db564bc9-sr5j5:/app/psga# aws s3 cp s3://synthetic-data-dev/UKHSA/piero_test_remove/resultfiles.json .
download: s3://synthetic-data-dev/UKHSA/piero_test_remove/resultfiles.json to ./resultfiles.json

root@sars-cov-2-pipeline-minikube-86db564bc9-sr5j5:/app/psga# head ./resultfiles.json 
{
    "2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb": [
        "s3://synthetic-data-dev/UKHSA/piero_test_remove/contamination_removal/cleaned_fastq/2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq.gz",
        "s3://synthetic-data-dev/UKHSA/piero_test_remove/contamination_removal/counting/2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.txt",
        "s3://synthetic-data-dev/UKHSA/piero_test_remove/fastqc/2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb_fastqc.zip",
        "s3://synthetic-data-dev/UKHSA/piero_test_remove/ncov2019-artic/output_bam/2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.primertrimmed.rg.sorted.bam",
        "s3://synthetic-data-dev/UKHSA/piero_test_remove/ncov2019-artic/output_bam/2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.primertrimmed.rg.sorted.bam.bai",
        "s3://synthetic-data-dev/UKHSA/piero_test_remove/ncov2019-artic/output_fasta/2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.consensus.fa",
        "s3://synthetic-data-dev/UKHSA/piero_test_remove/ncov2019-artic/output_fasta/2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.preconsensus.fa",
        "s3://synthetic-data-dev/UKHSA/piero_test_remove/ncov2019-artic/output_variants/2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.pass.vcf.gz",
```