### PR TITLE
PSG-1119: use snakemake 7.16.0 which includes this fix:

### DIFF
--- a/docker/Dockerfile.pangolin
+++ b/docker/Dockerfile.pangolin
@@ -10,7 +10,7 @@ RUN mamba env create -f /environment.yml -n pangolin \
 
 FROM debian:buster-slim
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends git procps ca-certificates awscli \
+  && apt-get install -y --no-install-recommends git procps ca-certificates \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
 
@@ -21,6 +21,7 @@ COPY docker/sars_cov_2.deps /
 
 RUN . /sars_cov_2.deps \
   && git clone https://github.com/cov-lineages/pangolin.git \
+  && pip install awscli==1.22.50 \
   && cd pangolin \
   && git checkout ${pangolin_commit} \
   && python setup.py install \

--- a/docker/pangolin_environment.yml
+++ b/docker/pangolin_environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - minimap2>=2.16
   - pip=19.3.1
   - python>=3.7
-  - snakemake-minimal<=6.8.0
+  - snakemake-minimal<=7.16.0
   - gofasta
   - ucsc-fatovcf>=426
   - usher>=0.5.4


### PR DESCRIPTION
https://github.com/snakemake/snakemake/pull/1894/files. Without this code, the installation of awscli crashes snakemake


Testing on awsbatch: 
```
(venv-psga-pipeline-3.10) pierodallepezze@CONGENICA-0256:~/psga-pipeline$ k exec -it sars-cov-2-pipeline-6c577c549-qt6dw -- bash 
root@sars-cov-2-pipeline-6c577c549-qt6dw:/app/psga# nextflow run . --run unknown_short --sequencing_technology unknown --kit none --metadata s3://psga-dev-pipeline-metadata/fb217fbc-271c-44c9-b17e-fa9497044c10.csv --output_path s3://psga-dev-results/dev/piero-out-20221005-1530 -resume
N E X T F L O W  ~  version 22.09.7-edge
Launching `./main.nf` [evil_murdock] DSL2 - revision: 9ec850e2bd
[ec/457a55] Cached process > psga:check_metadata (fb217fbc-271c-44c9-b17e-fa9497044c10.csv)
[32/bd91d0] Cached process > psga:stage_sample_file (2 - aa6719d0-0d82-414e-941a-d4c8853d86e6.fasta)
[07/57f8b9] Cached process > psga:stage_sample_file (1 - 9ca52070-39e5-41c9-8edc-948afd3225b9.fasta)
[65/aef657] Cached process > psga:stage_sample_file (3 - d266bb62-c4ef-4f90-96f3-cd6fda46bf53.fasta)
[f2/47724a] Cached process > psga:reheader:standardise_fasta (1 - aa6719d0-0d82-414e-941a-d4c8853d86e6.fasta)
[9c/af6ffe] Cached process > psga:reheader:standardise_fasta (2 - 9ca52070-39e5-41c9-8edc-948afd3225b9.fasta)
[19/16b4a0] Cached process > psga:stage_sample_file (4 - 26681a5d-7b83-46d6-989a-acf2d7fc7c9b.fasta)
[55/bf74ab] Cached process > psga:stage_sample_file (5 - 5f5d79a7-08e5-4cd1-9e44-2660f93f8cac.fasta)
[ad/f59754] Cached process > psga:reheader:standardise_fasta (3 - d266bb62-c4ef-4f90-96f3-cd6fda46bf53.fasta)
[4f/b51fae] Cached process > psga:reheader:reheader_fasta (2 - 9ca52070-39e5-41c9-8edc-948afd3225b9.consensus.fa)
[3e/536e92] Cached process > psga:reheader:reheader_fasta (1 - aa6719d0-0d82-414e-941a-d4c8853d86e6.consensus.fa)
[cb/acdc62] Cached process > psga:reheader:standardise_fasta (4 - 26681a5d-7b83-46d6-989a-acf2d7fc7c9b.fasta)
[61/a99658] Cached process > psga:reheader:standardise_fasta (5 - 5f5d79a7-08e5-4cd1-9e44-2660f93f8cac.fasta)
[30/976ff2] Cached process > psga:reheader:reheader_fasta (3 - d266bb62-c4ef-4f90-96f3-cd6fda46bf53.consensus.fa)
[3f/f506fa] Cached process > psga:reheader:store_reheadered_qc_passed_fasta (1 - 9ca52070-39e5-41c9-8edc-948afd3225b9.fasta)
[bc/1debb8] Cached process > psga:reheader:store_reheadered_qc_passed_fasta (2 - aa6719d0-0d82-414e-941a-d4c8853d86e6.fasta)
[01/749c74] Cached process > psga:reheader:reheader_fasta (4 - 26681a5d-7b83-46d6-989a-acf2d7fc7c9b.consensus.fa)
[40/10dba1] Cached process > psga:reheader:reheader_fasta (5 - 5f5d79a7-08e5-4cd1-9e44-2660f93f8cac.consensus.fa)
[08/a75f49] Cached process > psga:reheader:store_reheadered_qc_passed_fasta (3 - d266bb62-c4ef-4f90-96f3-cd6fda46bf53.fasta)
[d2/c94c5f] Cached process > psga:reheader:store_reheadered_qc_passed_fasta (4 - 26681a5d-7b83-46d6-989a-acf2d7fc7c9b.fasta)
[27/ea9b26] Cached process > psga:reheader:store_reheadered_qc_passed_fasta (5 - 5f5d79a7-08e5-4cd1-9e44-2660f93f8cac.fasta)
[ab/0c289f] Submitted process > psga:pangolin (2 - aa6719d0-0d82-414e-941a-d4c8853d86e6.fasta)
[1f/607aa6] Submitted process > psga:pangolin (4 - 26681a5d-7b83-46d6-989a-acf2d7fc7c9b.fasta)
[1a/f8603c] Submitted process > psga:pangolin (1 - 9ca52070-39e5-41c9-8edc-948afd3225b9.fasta)
[87/e953cf] Submitted process > psga:pangolin (3 - d266bb62-c4ef-4f90-96f3-cd6fda46bf53.fasta)
[98/d3e2ab] Submitted process > psga:pangolin (5 - 5f5d79a7-08e5-4cd1-9e44-2660f93f8cac.fasta)
[d8/8e072f] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[25/59dd7b] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
```
results.csv content looks correct: 
```
root@sars-cov-2-pipeline-6c577c549-qt6dw:/app/psga# cat results.csv 
SAMPLE_ID,STATUS,NUM_ALIGNED_READS,PCT_COVERED_BASES,PCT_N_BASES,LONGEST_NO_N_RUN,QC_PASS,LINEAGE,CONFLICT,AMBIGUITY_SCORE,SCORPIO_CALL,SCORPIO_SUPPORT,SCORPIO_CONFLICT,SCORPIO_NOTES,VERSION,PANGOLIN_VERSION,SCORPIO_VERSION,CONSTELLATION_VERSION,IS_DESIGNATED,QC_STATUS,QC_NOTES,NOTE
9ca52070-39e5-41c9-8edc-948afd3225b9,Completed,,,,,,BA.4.6,0.0,,Omicron (BA.4-like),1.0,0.0,scorpio call: Alt alleles 64; Ref alleles 0; Amb alleles 0; Oth alleles 0,PUSHER-v1.14,4.1.2,0.3.17,v0.1.10,False,pass,Ambiguous_content:0.02,Usher placements: BA.4.6(1/1)
aa6719d0-0d82-414e-941a-d4c8853d86e6,Completed,,,,,,AY.43,0.0,,Delta (B.1.617.2-like),1.0,0.0,scorpio call: Alt alleles 13; Ref alleles 0; Amb alleles 0; Oth alleles 0,PUSHER-v1.14,4.1.2,0.3.17,v0.1.10,False,pass,Ambiguous_content:0.02,Usher placements: AY.43(1/1)
d266bb62-c4ef-4f90-96f3-cd6fda46bf53,Completed,,,,,,B.1.1.464,0.0,,,,,,PUSHER-v1.14,4.1.2,0.3.17,v0.1.10,False,pass,Ambiguous_content:0.02,Usher placements: B.1.1.464(1/1)
26681a5d-7b83-46d6-989a-acf2d7fc7c9b,Completed,,,,,,BA.5.2.1,0.0,,Omicron (BA.5-like),0.98,0.02,scorpio call: Alt alleles 60; Ref alleles 1; Amb alleles 0; Oth alleles 0,PUSHER-v1.14,4.1.2,0.3.17,v0.1.10,False,pass,Ambiguous_content:0.02,Usher placements: BA.5.2.1(2/2)
5f5d79a7-08e5-4cd1-9e44-2660f93f8cac,Completed,,,,,,BA.5,0.0,,Probable Omicron (BA.5-like),0.93,0.05,scorpio call: Alt alleles 57; Ref alleles 3; Amb alleles 1; Oth alleles 0,PUSHER-v1.14,4.1.2,0.3.17,v0.1.10,False,pass,Ambiguous_content:0.02,Usher placements: BA.5(1/1)
```

fasta file executed on pangolin docker image: 
```
(venv-psga-pipeline-3.10) pierodallepezze@CONGENICA-0256:~/psga-pipeline$ docker run -it --rm 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev/pangolin:1.0.0 bash 
root@67c3002d2928:/# pangolin 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta 
****
Pangolin running in usher mode.
****
Maximum ambiguity allowed is 0.3.
****
Query file:	/19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta
****
Data files found:
usher_pb:	/opt/conda/envs/pangolin/lib/python3.8/site-packages/pangolin_data/data/lineageTree.pb
****
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Job stats:
job                      count    min threads    max threads
---------------------  -------  -------------  -------------
align_to_reference           1              1              1
all                          1              1              1
cache_sequence_assign        1              1              1
create_seq_hash              1              1              1
get_constellations           1              1              1
merged_info                  1              1              1
scorpio                      1              1              1
sequence_qc                  1              1              1
total                        8              1              1

Select jobs to execute...
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Select jobs to execute...
Select jobs to execute...
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Select jobs to execute...
Select jobs to execute...
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Select jobs to execute...
****
Query sequences collapsed from 1 to 1 unique sequences.
Select jobs to execute...
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Select jobs to execute...
Select jobs to execute...
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Select jobs to execute...
****
0 sequences assigned via designations.
Select jobs to execute...
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Select jobs to execute...
****
Running sequence QC
Total passing QC: 1
Select jobs to execute...
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Select jobs to execute...
Select jobs to execute...
Complete log: .snakemake/log/2022-10-14T141154.118500.snakemake.log
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Job stats:
job                count    min threads    max threads
---------------  -------  -------------  -------------
all                    1              1              1
usher_cache            1              1              1
usher_inference        1              1              1
usher_to_report        1              1              1
total                  4              1              1

Select jobs to execute...
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Select jobs to execute...
Select jobs to execute...
Using UShER as inference engine.
Select jobs to execute...
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 1 (use --cores to define parallelism)
Rules claiming more threads will be scaled down.
Select jobs to execute...
Select jobs to execute...
Complete log: .snakemake/log/2022-10-14T141204.538188.snakemake.log
****
```
Docker image ships aws cli:
```
Output file written to: /lineage_report.csv
root@67c3002d2928:/# aws --version
aws-cli/1.22.50 Python/3.8.13 Linux/5.15.0-46-generic botocore/1.23.50
```