### PR TITLE
PSG-1141: add file type to pipeline resultfiles.json

### DIFF
--- a/jenkins/sars_cov_2.py
+++ b/jenkins/sars_cov_2.py
@@ -33,7 +33,7 @@ def get_expected_output_files(output_path: str, sample_ids: List[str], sequencin
         sequencing_technology=sequencing_technology,
     )
     # generate a unified list of paths as non-sample results files must also be included
-    output_files = [path for sample_paths in output_files_per_sample.values() for path in sample_paths]
+    output_files = [f["file"] for sample_files in output_files_per_sample.values() for f in sample_files]
 
     output_files.extend(
         [join_path(output_path, "logs", f) for f in ["check_metadata.log", "generate_pipeline_results_files.log"]]

--- a/scripts/util/slugs.py
+++ b/scripts/util/slugs.py
@@ -1,0 +1,28 @@
+from os.path import join as join_path  # used to join FS paths and S3 URIs
+from typing import Dict, List
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FileType:
+    extension: str = field(metadata={"required": True})
+    filetype: str = field(metadata={"required": True})
+
+
+def get_file_with_type(
+    output_path: str,
+    inner_dirs: List[str],
+    filetypes: List[FileType],
+    sample_id: str,
+) -> List[Dict[str, str]]:
+    """
+    Return a dictionary { "file": "path/to/sample_id.ext", "type": "filetype" }
+    """
+    sample_files = [
+        {
+            "file": join_path(output_path, *inner_dirs, f"{sample_id}{elem.extension}"),
+            "type": f"{elem.filetype}",
+        }
+        for elem in filetypes
+    ]
+    return sample_files

--- a/tests/common/test_concat_csv.py
+++ b/tests/common/test_concat_csv.py
@@ -6,7 +6,7 @@ from pandas.testing import assert_frame_equal
 
 from scripts.common.concat_csv import concat_csv, concat
 from scripts.util.metadata import SAMPLE_ID
-from tests.utils_tests import assert_dataframes_are_equal
+from tests.utils_tests import assert_csvs_are_equal
 
 
 def test_concat_no_file_found_error(tmp_path):
@@ -32,7 +32,7 @@ def test_concat(tmp_path, test_data_path):
 
     assert output_csv_path.is_file()
 
-    assert_dataframes_are_equal(output_csv_path, expected_output_csv_path, SAMPLE_ID)
+    assert_csvs_are_equal(output_csv_path, expected_output_csv_path, SAMPLE_ID)
 
     df_exp = pd.read_csv(expected_output_csv_path)
 
@@ -62,4 +62,4 @@ def test_concat_csv(tmp_path, test_data_path):
 
     assert rv.exit_code == 0
 
-    assert_dataframes_are_equal(output_csv_path, expected_output_csv_path, SAMPLE_ID)
+    assert_csvs_are_equal(output_csv_path, expected_output_csv_path, SAMPLE_ID)

--- a/tests/common/test_format_genotyping.py
+++ b/tests/common/test_format_genotyping.py
@@ -6,7 +6,7 @@ from scripts.common.format_genotyping import (
     format_genotyping,
     TYPING_SAMPLE_ID_COL,
 )
-from tests.utils_tests import assert_dataframes_are_equal
+from tests.utils_tests import assert_csvs_are_equal
 
 
 @pytest.mark.parametrize(
@@ -33,7 +33,7 @@ def test_process_typing(
     expected_typing_output_path = test_data_path / "typing" / expected_typing_output_csv
     output_path = tmp_path / "typing_output.csv"
     process_typing(input_path, output_path, input_sample_id_col, input_type_col)
-    assert_dataframes_are_equal(output_path, expected_typing_output_path, TYPING_SAMPLE_ID_COL)
+    assert_csvs_are_equal(output_path, expected_typing_output_path, TYPING_SAMPLE_ID_COL)
 
 
 @pytest.mark.parametrize(
@@ -71,4 +71,4 @@ def test_typing(tmp_path, test_data_path, input_file, input_sample_id_col, input
         ],
     )
     assert rv.exit_code == 0
-    assert_dataframes_are_equal(output_path, expected_typing_output_path, TYPING_SAMPLE_ID_COL)
+    assert_csvs_are_equal(output_path, expected_typing_output_path, TYPING_SAMPLE_ID_COL)

--- a/tests/common/test_primer_autodetection.py
+++ b/tests/common/test_primer_autodetection.py
@@ -15,7 +15,7 @@ from scripts.common.primer_autodetection import (
     PRIMER_DATA_SUFFIX,
     UNKNOWN,
 )
-from tests.utils_tests import assert_dataframes_are_equal, assert_files_are_equal
+from tests.utils_tests import assert_csvs_are_equal, assert_files_are_equal
 
 DEFAULT_PRIMER = "ARTIC_V4-1"
 
@@ -24,14 +24,14 @@ def assert_primer_detection(sample_id, tmp_path, input_path):
     output_file = f"{sample_id}{PRIMER_DETECTION_SUFFIX}"
     output_path = tmp_path / output_file
     expected_output_path = input_path / output_file
-    assert_dataframes_are_equal(output_path, expected_output_path, PRIMER_AUTODETECTION_PRIMER_COL)
+    assert_csvs_are_equal(output_path, expected_output_path, PRIMER_AUTODETECTION_PRIMER_COL)
 
 
 def assert_primer_data(sample_id, tmp_path, input_path):
     output_file = f"{sample_id}{PRIMER_DATA_SUFFIX}"
     output_path = tmp_path / output_file
     expected_output_path = input_path / output_file
-    assert_dataframes_are_equal(output_path, expected_output_path, PRIMER_AUTODETECTION_SAMPLE_ID_COL)
+    assert_csvs_are_equal(output_path, expected_output_path, PRIMER_AUTODETECTION_SAMPLE_ID_COL)
 
 
 def assert_selected_primer_file(sample_id, test_data_path, tmp_path, found_dir):

--- a/tests/sars_cov_2/test_generate_pipeline_results_files.py
+++ b/tests/sars_cov_2/test_generate_pipeline_results_files.py
@@ -4,7 +4,7 @@ from click.testing import CliRunner
 
 from scripts.sars_cov_2.generate_pipeline_results_files import generate_pipeline_results_files
 from scripts.util.metadata import SAMPLE_ID
-from tests.utils_tests import assert_dataframes_are_equal, assert_jsons_are_equal
+from tests.utils_tests import assert_csvs_are_equal, assert_jsons_are_equal
 
 
 @pytest.mark.parametrize(
@@ -120,7 +120,7 @@ def test_generate_pipeline_results_files(
 
     # assert results.csv
     exp_output_results_csv_file = test_data_path / "pipeline_results_files" / exp_results_csv
-    assert_dataframes_are_equal(output_results_csv_file, exp_output_results_csv_file, SAMPLE_ID)
+    assert_csvs_are_equal(output_results_csv_file, exp_output_results_csv_file, SAMPLE_ID)
 
     # assert results.json
     exp_output_results_json_file = test_data_path / "pipeline_results_files" / exp_results_json
@@ -132,12 +132,9 @@ def test_generate_pipeline_results_files(
     with open(output_resultfiles_json_file) as json_fd:
         calc_resultfiles_json_dict = json.load(json_fd)
 
-    exp_result_files_json_dict_full_path = {
-        sample_id: sorted([f"{str(output_path)}/{f}" for f in files])
-        for sample_id, files in exp_resultfiles_json_dict.items()
-    }
-    calc_result_files_json_dict_sorted = {
-        sample_id: sorted(files) for sample_id, files in calc_resultfiles_json_dict.items()
+    exp_resultfiles_json_dict_full_path = {
+        sample_id: [{k: f"{output_path}/{v}" if k == "file" else v for k, v in d.items()} for d in list_of_dicts]
+        for sample_id, list_of_dicts in exp_resultfiles_json_dict.items()
     }
 
-    assert exp_result_files_json_dict_full_path == calc_result_files_json_dict_sorted
+    assert exp_resultfiles_json_dict_full_path == calc_resultfiles_json_dict

--- a/tests/test_data/pipeline_results_files/resultfiles_illumina.json
+++ b/tests/test_data/pipeline_results_files/resultfiles_illumina.json
@@ -1,107 +1,380 @@
 {
     "0774181d-fb20-4a73-b887-38af7eda9b38": [
-        "contamination_removal/cleaned_fastq/0774181d-fb20-4a73-b887-38af7eda9b38_1.fastq.gz",
-        "contamination_removal/cleaned_fastq/0774181d-fb20-4a73-b887-38af7eda9b38_2.fastq.gz",
-        "contamination_removal/counting/0774181d-fb20-4a73-b887-38af7eda9b38.txt",
-        "contamination_removal/0774181d-fb20-4a73-b887-38af7eda9b38_contamination_removal.csv",
-        "fastqc/0774181d-fb20-4a73-b887-38af7eda9b38_1_fastqc.zip",
-        "fastqc/0774181d-fb20-4a73-b887-38af7eda9b38_2_fastqc.zip",
-        "primer_autodetection/0774181d-fb20-4a73-b887-38af7eda9b38_primer_data.csv",
-        "primer_autodetection/0774181d-fb20-4a73-b887-38af7eda9b38_primer_detection.csv",
-        "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.mapped.primertrimmed.sorted.bam",
-        "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.mapped.primertrimmed.sorted.bam.bai",
-        "ncov2019-artic/output_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.primertrimmed.consensus.fa",
-        "ncov2019-artic/output_plots/0774181d-fb20-4a73-b887-38af7eda9b38.depth.png",
-        "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.typing.csv",
-        "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.variants.csv",
-        "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.csq.vcf",
-        "ncov2019-artic/output_variants/0774181d-fb20-4a73-b887-38af7eda9b38.variants.tsv"
+        {
+            "file": "contamination_removal/cleaned_fastq/0774181d-fb20-4a73-b887-38af7eda9b38_1.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/cleaned_fastq/0774181d-fb20-4a73-b887-38af7eda9b38_2.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/0774181d-fb20-4a73-b887-38af7eda9b38.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/0774181d-fb20-4a73-b887-38af7eda9b38_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/0774181d-fb20-4a73-b887-38af7eda9b38_1_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "fastqc/0774181d-fb20-4a73-b887-38af7eda9b38_2_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/0774181d-fb20-4a73-b887-38af7eda9b38_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/0774181d-fb20-4a73-b887-38af7eda9b38_primer_detection.csv",
+            "type": "csv/primer-detection"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.mapped.primertrimmed.sorted.bam",
+            "type": "bam/final"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.mapped.primertrimmed.sorted.bam.bai",
+            "type": "bai/final"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.primertrimmed.consensus.fa",
+            "type": "fasta/consensus"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.typing.csv",
+            "type": "csv/typing"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.variants.csv",
+            "type": "csv/typing-variants"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.csq.vcf",
+            "type": "vcf/typing-consequences"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/0774181d-fb20-4a73-b887-38af7eda9b38.variants.tsv",
+            "type": "tsv/final"
+        },
+        {
+            "file": "ncov2019-artic/output_plots/0774181d-fb20-4a73-b887-38af7eda9b38.depth.png",
+            "type": "png/qc"
+        }
     ],
     "56a63f60-764d-4fc7-8764-a46023cbe324": [
-        "contamination_removal/cleaned_fastq/56a63f60-764d-4fc7-8764-a46023cbe324_1.fastq.gz",
-        "contamination_removal/cleaned_fastq/56a63f60-764d-4fc7-8764-a46023cbe324_2.fastq.gz",
-        "contamination_removal/counting/56a63f60-764d-4fc7-8764-a46023cbe324.txt",
-        "contamination_removal/56a63f60-764d-4fc7-8764-a46023cbe324_contamination_removal.csv",
-        "fastqc/56a63f60-764d-4fc7-8764-a46023cbe324_1_fastqc.zip",
-        "fastqc/56a63f60-764d-4fc7-8764-a46023cbe324_2_fastqc.zip",
-        "primer_autodetection/56a63f60-764d-4fc7-8764-a46023cbe324_primer_data.csv",
-        "primer_autodetection/56a63f60-764d-4fc7-8764-a46023cbe324_primer_detection.csv",
-        "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.mapped.primertrimmed.sorted.bam",
-        "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.mapped.primertrimmed.sorted.bam.bai",
-        "ncov2019-artic/output_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.primertrimmed.consensus.fa",
-        "ncov2019-artic/output_plots/56a63f60-764d-4fc7-8764-a46023cbe324.depth.png",
-        "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.typing.csv",
-        "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.variants.csv",
-        "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.csq.vcf",
-        "ncov2019-artic/output_variants/56a63f60-764d-4fc7-8764-a46023cbe324.variants.tsv",
-        "reheadered-fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta"
+        {
+            "file": "contamination_removal/cleaned_fastq/56a63f60-764d-4fc7-8764-a46023cbe324_1.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/cleaned_fastq/56a63f60-764d-4fc7-8764-a46023cbe324_2.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/56a63f60-764d-4fc7-8764-a46023cbe324.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/56a63f60-764d-4fc7-8764-a46023cbe324_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/56a63f60-764d-4fc7-8764-a46023cbe324_1_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "fastqc/56a63f60-764d-4fc7-8764-a46023cbe324_2_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/56a63f60-764d-4fc7-8764-a46023cbe324_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/56a63f60-764d-4fc7-8764-a46023cbe324_primer_detection.csv",
+            "type": "csv/primer-detection"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.mapped.primertrimmed.sorted.bam",
+            "type": "bam/final"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.mapped.primertrimmed.sorted.bam.bai",
+            "type": "bai/final"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.primertrimmed.consensus.fa",
+            "type": "fasta/consensus"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.typing.csv",
+            "type": "csv/typing"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.variants.csv",
+            "type": "csv/typing-variants"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.csq.vcf",
+            "type": "vcf/typing-consequences"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/56a63f60-764d-4fc7-8764-a46023cbe324.variants.tsv",
+            "type": "tsv/final"
+        },
+        {
+            "file": "ncov2019-artic/output_plots/56a63f60-764d-4fc7-8764-a46023cbe324.depth.png",
+            "type": "png/qc"
+        },
+        {
+            "file": "reheadered-fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta",
+            "type": "fasta/final"
+        }
     ],
     "985347c5-ff6a-454c-ac34-bc353d05dd70": [
-        "contamination_removal/cleaned_fastq/985347c5-ff6a-454c-ac34-bc353d05dd70_1.fastq.gz",
-        "contamination_removal/cleaned_fastq/985347c5-ff6a-454c-ac34-bc353d05dd70_2.fastq.gz",
-        "contamination_removal/counting/985347c5-ff6a-454c-ac34-bc353d05dd70.txt",
-        "contamination_removal/985347c5-ff6a-454c-ac34-bc353d05dd70_contamination_removal.csv",
-        "fastqc/985347c5-ff6a-454c-ac34-bc353d05dd70_1_fastqc.zip",
-        "fastqc/985347c5-ff6a-454c-ac34-bc353d05dd70_2_fastqc.zip",
-        "primer_autodetection/985347c5-ff6a-454c-ac34-bc353d05dd70_primer_data.csv",
-        "primer_autodetection/985347c5-ff6a-454c-ac34-bc353d05dd70_primer_detection.csv"
+        {
+            "file": "contamination_removal/cleaned_fastq/985347c5-ff6a-454c-ac34-bc353d05dd70_1.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/cleaned_fastq/985347c5-ff6a-454c-ac34-bc353d05dd70_2.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/985347c5-ff6a-454c-ac34-bc353d05dd70.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/985347c5-ff6a-454c-ac34-bc353d05dd70_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/985347c5-ff6a-454c-ac34-bc353d05dd70_1_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "fastqc/985347c5-ff6a-454c-ac34-bc353d05dd70_2_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/985347c5-ff6a-454c-ac34-bc353d05dd70_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/985347c5-ff6a-454c-ac34-bc353d05dd70_primer_detection.csv",
+            "type": "csv/primer-detection"
+        }
     ],
     "a0951432-cd94-45b5-96d5-b721c037a451": [
-        "contamination_removal/cleaned_fastq/a0951432-cd94-45b5-96d5-b721c037a451_1.fastq.gz",
-        "contamination_removal/cleaned_fastq/a0951432-cd94-45b5-96d5-b721c037a451_2.fastq.gz",
-        "contamination_removal/counting/a0951432-cd94-45b5-96d5-b721c037a451.txt",
-        "contamination_removal/a0951432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
-        "fastqc/a0951432-cd94-45b5-96d5-b721c037a451_1_fastqc.zip",
-        "fastqc/a0951432-cd94-45b5-96d5-b721c037a451_2_fastqc.zip",
-        "primer_autodetection/a0951432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
-        "primer_autodetection/a0951432-cd94-45b5-96d5-b721c037a451_primer_detection.csv",
-        "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.mapped.primertrimmed.sorted.bam",
-        "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.mapped.primertrimmed.sorted.bam.bai",
-        "ncov2019-artic/output_fasta/a0951432-cd94-45b5-96d5-b721c037a451.primertrimmed.consensus.fa",
-        "ncov2019-artic/output_plots/a0951432-cd94-45b5-96d5-b721c037a451.depth.png",
-        "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.typing.csv",
-        "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.variants.csv",
-        "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.csq.vcf",
-        "ncov2019-artic/output_variants/a0951432-cd94-45b5-96d5-b721c037a451.variants.tsv",
-        "reheadered-fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta"
+        {
+            "file": "contamination_removal/cleaned_fastq/a0951432-cd94-45b5-96d5-b721c037a451_1.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/cleaned_fastq/a0951432-cd94-45b5-96d5-b721c037a451_2.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/a0951432-cd94-45b5-96d5-b721c037a451.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/a0951432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/a0951432-cd94-45b5-96d5-b721c037a451_1_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "fastqc/a0951432-cd94-45b5-96d5-b721c037a451_2_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/a0951432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/a0951432-cd94-45b5-96d5-b721c037a451_primer_detection.csv",
+            "type": "csv/primer-detection"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.mapped.primertrimmed.sorted.bam",
+            "type": "bam/final"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.mapped.primertrimmed.sorted.bam.bai",
+            "type": "bai/final"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/a0951432-cd94-45b5-96d5-b721c037a451.primertrimmed.consensus.fa",
+            "type": "fasta/consensus"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.typing.csv",
+            "type": "csv/typing"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.variants.csv",
+            "type": "csv/typing-variants"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.csq.vcf",
+            "type": "vcf/typing-consequences"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/a0951432-cd94-45b5-96d5-b721c037a451.variants.tsv",
+            "type": "tsv/final"
+        },
+        {
+            "file": "ncov2019-artic/output_plots/a0951432-cd94-45b5-96d5-b721c037a451.depth.png",
+            "type": "png/qc"
+        },
+        {
+            "file": "reheadered-fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta",
+            "type": "fasta/final"
+        }
     ],
     "b1131432-cd94-45b5-96d5-b721c037a451": [
-        "contamination_removal/cleaned_fastq/b1131432-cd94-45b5-96d5-b721c037a451_1.fastq.gz",
-        "contamination_removal/cleaned_fastq/b1131432-cd94-45b5-96d5-b721c037a451_2.fastq.gz",
-        "contamination_removal/counting/b1131432-cd94-45b5-96d5-b721c037a451.txt",
-        "contamination_removal/b1131432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
-        "fastqc/b1131432-cd94-45b5-96d5-b721c037a451_1_fastqc.zip",
-        "fastqc/b1131432-cd94-45b5-96d5-b721c037a451_2_fastqc.zip",
-        "primer_autodetection/b1131432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
-        "primer_autodetection/b1131432-cd94-45b5-96d5-b721c037a451_primer_detection.csv"
+        {
+            "file": "contamination_removal/cleaned_fastq/b1131432-cd94-45b5-96d5-b721c037a451_1.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/cleaned_fastq/b1131432-cd94-45b5-96d5-b721c037a451_2.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/b1131432-cd94-45b5-96d5-b721c037a451.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/b1131432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/b1131432-cd94-45b5-96d5-b721c037a451_1_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "fastqc/b1131432-cd94-45b5-96d5-b721c037a451_2_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/b1131432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/b1131432-cd94-45b5-96d5-b721c037a451_primer_detection.csv",
+            "type": "csv/primer-detection"
+        }
     ],
     "e2331432-cd94-45b5-96d5-b721c037a451": [
-        "contamination_removal/cleaned_fastq/e2331432-cd94-45b5-96d5-b721c037a451_1.fastq.gz",
-        "contamination_removal/cleaned_fastq/e2331432-cd94-45b5-96d5-b721c037a451_2.fastq.gz",
-        "contamination_removal/counting/e2331432-cd94-45b5-96d5-b721c037a451.txt",
-        "contamination_removal/e2331432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
-        "fastqc/e2331432-cd94-45b5-96d5-b721c037a451_1_fastqc.zip",
-        "fastqc/e2331432-cd94-45b5-96d5-b721c037a451_2_fastqc.zip",
-        "primer_autodetection/e2331432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
-        "primer_autodetection/e2331432-cd94-45b5-96d5-b721c037a451_primer_detection.csv"
+        {
+            "file": "contamination_removal/cleaned_fastq/e2331432-cd94-45b5-96d5-b721c037a451_1.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/cleaned_fastq/e2331432-cd94-45b5-96d5-b721c037a451_2.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/e2331432-cd94-45b5-96d5-b721c037a451.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/e2331432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/e2331432-cd94-45b5-96d5-b721c037a451_1_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "fastqc/e2331432-cd94-45b5-96d5-b721c037a451_2_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/e2331432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/e2331432-cd94-45b5-96d5-b721c037a451_primer_detection.csv",
+            "type": "csv/primer-detection"
+        }
     ],
     "e80f3c63-d139-4c14-bd72-7a43897ab40d": [
-        "contamination_removal/cleaned_fastq/e80f3c63-d139-4c14-bd72-7a43897ab40d_1.fastq.gz",
-        "contamination_removal/cleaned_fastq/e80f3c63-d139-4c14-bd72-7a43897ab40d_2.fastq.gz",
-        "contamination_removal/counting/e80f3c63-d139-4c14-bd72-7a43897ab40d.txt",
-        "contamination_removal/e80f3c63-d139-4c14-bd72-7a43897ab40d_contamination_removal.csv",
-        "fastqc/e80f3c63-d139-4c14-bd72-7a43897ab40d_1_fastqc.zip",
-        "fastqc/e80f3c63-d139-4c14-bd72-7a43897ab40d_2_fastqc.zip",
-        "primer_autodetection/e80f3c63-d139-4c14-bd72-7a43897ab40d_primer_data.csv",
-        "primer_autodetection/e80f3c63-d139-4c14-bd72-7a43897ab40d_primer_detection.csv",
-        "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.mapped.primertrimmed.sorted.bam",
-        "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.mapped.primertrimmed.sorted.bam.bai",
-        "ncov2019-artic/output_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.primertrimmed.consensus.fa",
-        "ncov2019-artic/output_plots/e80f3c63-d139-4c14-bd72-7a43897ab40d.depth.png",
-        "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.typing.csv",
-        "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.variants.csv",
-        "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.csq.vcf",
-        "ncov2019-artic/output_variants/e80f3c63-d139-4c14-bd72-7a43897ab40d.variants.tsv",
-        "reheadered-fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta"
+        {
+            "file": "contamination_removal/cleaned_fastq/e80f3c63-d139-4c14-bd72-7a43897ab40d_1.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/cleaned_fastq/e80f3c63-d139-4c14-bd72-7a43897ab40d_2.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/e80f3c63-d139-4c14-bd72-7a43897ab40d.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/e80f3c63-d139-4c14-bd72-7a43897ab40d_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/e80f3c63-d139-4c14-bd72-7a43897ab40d_1_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "fastqc/e80f3c63-d139-4c14-bd72-7a43897ab40d_2_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/e80f3c63-d139-4c14-bd72-7a43897ab40d_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/e80f3c63-d139-4c14-bd72-7a43897ab40d_primer_detection.csv",
+            "type": "csv/primer-detection"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.mapped.primertrimmed.sorted.bam",
+            "type": "bam/final"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.mapped.primertrimmed.sorted.bam.bai",
+            "type": "bai/final"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.primertrimmed.consensus.fa",
+            "type": "fasta/consensus"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.typing.csv",
+            "type": "csv/typing"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.variants.csv",
+            "type": "csv/typing-variants"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.csq.vcf",
+            "type": "vcf/typing-consequences"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/e80f3c63-d139-4c14-bd72-7a43897ab40d.variants.tsv",
+            "type": "tsv/final"
+        },
+        {
+            "file": "ncov2019-artic/output_plots/e80f3c63-d139-4c14-bd72-7a43897ab40d.depth.png",
+            "type": "png/qc"
+        },
+        {
+            "file": "reheadered-fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta",
+            "type": "fasta/final"
+        }
     ]
 }

--- a/tests/test_data/pipeline_results_files/resultfiles_ont.json
+++ b/tests/test_data/pipeline_results_files/resultfiles_ont.json
@@ -1,101 +1,356 @@
 {
     "0774181d-fb20-4a73-b887-38af7eda9b38": [
-        "contamination_removal/cleaned_fastq/0774181d-fb20-4a73-b887-38af7eda9b38.fastq.gz",
-        "contamination_removal/counting/0774181d-fb20-4a73-b887-38af7eda9b38.txt",
-        "contamination_removal/0774181d-fb20-4a73-b887-38af7eda9b38_contamination_removal.csv",
-        "fastqc/0774181d-fb20-4a73-b887-38af7eda9b38_fastqc.zip",
-        "primer_autodetection/0774181d-fb20-4a73-b887-38af7eda9b38_primer_data.csv",
-        "primer_autodetection/0774181d-fb20-4a73-b887-38af7eda9b38_primer_detection.csv",
-        "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.primertrimmed.rg.sorted.bam",
-        "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.primertrimmed.rg.sorted.bam.bai",
-        "ncov2019-artic/output_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.consensus.fa",
-        "ncov2019-artic/output_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.preconsensus.fa",
-        "ncov2019-artic/output_plots/0774181d-fb20-4a73-b887-38af7eda9b38.depth.png",
-        "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.typing.csv",
-        "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.variants.csv",
-        "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.csq.vcf",
-        "ncov2019-artic/output_variants/0774181d-fb20-4a73-b887-38af7eda9b38.pass.vcf.gz",
-        "ncov2019-artic/output_variants/0774181d-fb20-4a73-b887-38af7eda9b38.pass.vcf.gz.tbi"
+        {
+            "file": "contamination_removal/cleaned_fastq/0774181d-fb20-4a73-b887-38af7eda9b38.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/0774181d-fb20-4a73-b887-38af7eda9b38.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/0774181d-fb20-4a73-b887-38af7eda9b38_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/0774181d-fb20-4a73-b887-38af7eda9b38_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/0774181d-fb20-4a73-b887-38af7eda9b38_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/0774181d-fb20-4a73-b887-38af7eda9b38_primer_detection.csv",
+            "type": "csv/primer-detection"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.primertrimmed.rg.sorted.bam",
+            "type": "bam/final"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/0774181d-fb20-4a73-b887-38af7eda9b38.primertrimmed.rg.sorted.bam.bai",
+            "type": "bai/final"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.consensus.fa",
+            "type": "fasta/consensus"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.preconsensus.fa",
+            "type": "fasta/preconsensus"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.typing.csv",
+            "type": "csv/typing"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.variants.csv",
+            "type": "csv/typing-variants"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/0774181d-fb20-4a73-b887-38af7eda9b38.csq.vcf",
+            "type": "vcf/typing-consequences"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/0774181d-fb20-4a73-b887-38af7eda9b38.pass.vcf.gz",
+            "type": "vcf/final"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/0774181d-fb20-4a73-b887-38af7eda9b38.pass.vcf.gz.tbi",
+            "type": "tbi/final"
+        },
+        {
+            "file": "ncov2019-artic/output_plots/0774181d-fb20-4a73-b887-38af7eda9b38.depth.png",
+            "type": "png/qc"
+        }
     ],
     "56a63f60-764d-4fc7-8764-a46023cbe324": [
-        "contamination_removal/cleaned_fastq/56a63f60-764d-4fc7-8764-a46023cbe324.fastq.gz",
-        "contamination_removal/counting/56a63f60-764d-4fc7-8764-a46023cbe324.txt",
-        "contamination_removal/56a63f60-764d-4fc7-8764-a46023cbe324_contamination_removal.csv",
-        "fastqc/56a63f60-764d-4fc7-8764-a46023cbe324_fastqc.zip",
-        "primer_autodetection/56a63f60-764d-4fc7-8764-a46023cbe324_primer_data.csv",
-        "primer_autodetection/56a63f60-764d-4fc7-8764-a46023cbe324_primer_detection.csv",
-        "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.primertrimmed.rg.sorted.bam",
-        "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.primertrimmed.rg.sorted.bam.bai",
-        "ncov2019-artic/output_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.consensus.fa",
-        "ncov2019-artic/output_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.preconsensus.fa",
-        "ncov2019-artic/output_plots/56a63f60-764d-4fc7-8764-a46023cbe324.depth.png",
-        "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.typing.csv",
-        "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.variants.csv",
-        "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.csq.vcf",
-        "ncov2019-artic/output_variants/56a63f60-764d-4fc7-8764-a46023cbe324.pass.vcf.gz",
-        "ncov2019-artic/output_variants/56a63f60-764d-4fc7-8764-a46023cbe324.pass.vcf.gz.tbi",
-        "reheadered-fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta"
+        {
+            "file": "contamination_removal/cleaned_fastq/56a63f60-764d-4fc7-8764-a46023cbe324.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/56a63f60-764d-4fc7-8764-a46023cbe324.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/56a63f60-764d-4fc7-8764-a46023cbe324_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/56a63f60-764d-4fc7-8764-a46023cbe324_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/56a63f60-764d-4fc7-8764-a46023cbe324_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/56a63f60-764d-4fc7-8764-a46023cbe324_primer_detection.csv",
+            "type": "csv/primer-detection"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.primertrimmed.rg.sorted.bam",
+            "type": "bam/final"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/56a63f60-764d-4fc7-8764-a46023cbe324.primertrimmed.rg.sorted.bam.bai",
+            "type": "bai/final"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.consensus.fa",
+            "type": "fasta/consensus"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.preconsensus.fa",
+            "type": "fasta/preconsensus"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.typing.csv",
+            "type": "csv/typing"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.variants.csv",
+            "type": "csv/typing-variants"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/56a63f60-764d-4fc7-8764-a46023cbe324.csq.vcf",
+            "type": "vcf/typing-consequences"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/56a63f60-764d-4fc7-8764-a46023cbe324.pass.vcf.gz",
+            "type": "vcf/final"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/56a63f60-764d-4fc7-8764-a46023cbe324.pass.vcf.gz.tbi",
+            "type": "tbi/final"
+        },
+        {
+            "file": "ncov2019-artic/output_plots/56a63f60-764d-4fc7-8764-a46023cbe324.depth.png",
+            "type": "png/qc"
+        },
+        {
+            "file": "reheadered-fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta",
+            "type": "fasta/final"
+        }
     ],
     "985347c5-ff6a-454c-ac34-bc353d05dd70": [
-        "contamination_removal/cleaned_fastq/985347c5-ff6a-454c-ac34-bc353d05dd70.fastq.gz",
-        "contamination_removal/counting/985347c5-ff6a-454c-ac34-bc353d05dd70.txt",
-        "contamination_removal/985347c5-ff6a-454c-ac34-bc353d05dd70_contamination_removal.csv",
-        "fastqc/985347c5-ff6a-454c-ac34-bc353d05dd70_fastqc.zip",
-        "primer_autodetection/985347c5-ff6a-454c-ac34-bc353d05dd70_primer_data.csv",
-        "primer_autodetection/985347c5-ff6a-454c-ac34-bc353d05dd70_primer_detection.csv"
+        {
+            "file": "contamination_removal/cleaned_fastq/985347c5-ff6a-454c-ac34-bc353d05dd70.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/985347c5-ff6a-454c-ac34-bc353d05dd70.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/985347c5-ff6a-454c-ac34-bc353d05dd70_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/985347c5-ff6a-454c-ac34-bc353d05dd70_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/985347c5-ff6a-454c-ac34-bc353d05dd70_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/985347c5-ff6a-454c-ac34-bc353d05dd70_primer_detection.csv",
+            "type": "csv/primer-detection"
+        }
     ],
     "a0951432-cd94-45b5-96d5-b721c037a451": [
-        "contamination_removal/cleaned_fastq/a0951432-cd94-45b5-96d5-b721c037a451.fastq.gz",
-        "contamination_removal/counting/a0951432-cd94-45b5-96d5-b721c037a451.txt",
-        "contamination_removal/a0951432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
-        "fastqc/a0951432-cd94-45b5-96d5-b721c037a451_fastqc.zip",
-        "primer_autodetection/a0951432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
-        "primer_autodetection/a0951432-cd94-45b5-96d5-b721c037a451_primer_detection.csv",
-        "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.primertrimmed.rg.sorted.bam",
-        "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.primertrimmed.rg.sorted.bam.bai",
-        "ncov2019-artic/output_fasta/a0951432-cd94-45b5-96d5-b721c037a451.consensus.fa",
-        "ncov2019-artic/output_fasta/a0951432-cd94-45b5-96d5-b721c037a451.preconsensus.fa",
-        "ncov2019-artic/output_plots/a0951432-cd94-45b5-96d5-b721c037a451.depth.png",
-        "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.typing.csv",
-        "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.variants.csv",
-        "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.csq.vcf",
-        "ncov2019-artic/output_variants/a0951432-cd94-45b5-96d5-b721c037a451.pass.vcf.gz",
-        "ncov2019-artic/output_variants/a0951432-cd94-45b5-96d5-b721c037a451.pass.vcf.gz.tbi",
-        "reheadered-fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta"
+        {
+            "file": "contamination_removal/cleaned_fastq/a0951432-cd94-45b5-96d5-b721c037a451.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/a0951432-cd94-45b5-96d5-b721c037a451.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/a0951432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/a0951432-cd94-45b5-96d5-b721c037a451_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/a0951432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/a0951432-cd94-45b5-96d5-b721c037a451_primer_detection.csv",
+            "type": "csv/primer-detection"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.primertrimmed.rg.sorted.bam",
+            "type": "bam/final"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/a0951432-cd94-45b5-96d5-b721c037a451.primertrimmed.rg.sorted.bam.bai",
+            "type": "bai/final"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/a0951432-cd94-45b5-96d5-b721c037a451.consensus.fa",
+            "type": "fasta/consensus"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/a0951432-cd94-45b5-96d5-b721c037a451.preconsensus.fa",
+            "type": "fasta/preconsensus"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.typing.csv",
+            "type": "csv/typing"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.variants.csv",
+            "type": "csv/typing-variants"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/a0951432-cd94-45b5-96d5-b721c037a451.csq.vcf",
+            "type": "vcf/typing-consequences"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/a0951432-cd94-45b5-96d5-b721c037a451.pass.vcf.gz",
+            "type": "vcf/final"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/a0951432-cd94-45b5-96d5-b721c037a451.pass.vcf.gz.tbi",
+            "type": "tbi/final"
+        },
+        {
+            "file": "ncov2019-artic/output_plots/a0951432-cd94-45b5-96d5-b721c037a451.depth.png",
+            "type": "png/qc"
+        },
+        {
+            "file": "reheadered-fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta",
+            "type": "fasta/final"
+        }
     ],
     "b1131432-cd94-45b5-96d5-b721c037a451": [
-        "contamination_removal/cleaned_fastq/b1131432-cd94-45b5-96d5-b721c037a451.fastq.gz",
-        "contamination_removal/counting/b1131432-cd94-45b5-96d5-b721c037a451.txt",
-        "contamination_removal/b1131432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
-        "fastqc/b1131432-cd94-45b5-96d5-b721c037a451_fastqc.zip",
-        "primer_autodetection/b1131432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
-        "primer_autodetection/b1131432-cd94-45b5-96d5-b721c037a451_primer_detection.csv"
+        {
+            "file": "contamination_removal/cleaned_fastq/b1131432-cd94-45b5-96d5-b721c037a451.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/b1131432-cd94-45b5-96d5-b721c037a451.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/b1131432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/b1131432-cd94-45b5-96d5-b721c037a451_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/b1131432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/b1131432-cd94-45b5-96d5-b721c037a451_primer_detection.csv",
+            "type": "csv/primer-detection"
+        }
     ],
     "e2331432-cd94-45b5-96d5-b721c037a451": [
-        "contamination_removal/cleaned_fastq/e2331432-cd94-45b5-96d5-b721c037a451.fastq.gz",
-        "contamination_removal/counting/e2331432-cd94-45b5-96d5-b721c037a451.txt",
-        "contamination_removal/e2331432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
-        "fastqc/e2331432-cd94-45b5-96d5-b721c037a451_fastqc.zip",
-        "primer_autodetection/e2331432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
-        "primer_autodetection/e2331432-cd94-45b5-96d5-b721c037a451_primer_detection.csv"
+        {
+            "file": "contamination_removal/cleaned_fastq/e2331432-cd94-45b5-96d5-b721c037a451.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/e2331432-cd94-45b5-96d5-b721c037a451.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/e2331432-cd94-45b5-96d5-b721c037a451_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/e2331432-cd94-45b5-96d5-b721c037a451_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/e2331432-cd94-45b5-96d5-b721c037a451_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/e2331432-cd94-45b5-96d5-b721c037a451_primer_detection.csv",
+            "type": "csv/primer-detection"
+        }
     ],
     "e80f3c63-d139-4c14-bd72-7a43897ab40d": [
-        "contamination_removal/cleaned_fastq/e80f3c63-d139-4c14-bd72-7a43897ab40d.fastq.gz",
-        "contamination_removal/counting/e80f3c63-d139-4c14-bd72-7a43897ab40d.txt",
-        "contamination_removal/e80f3c63-d139-4c14-bd72-7a43897ab40d_contamination_removal.csv",
-        "fastqc/e80f3c63-d139-4c14-bd72-7a43897ab40d_fastqc.zip",
-        "primer_autodetection/e80f3c63-d139-4c14-bd72-7a43897ab40d_primer_data.csv",
-        "primer_autodetection/e80f3c63-d139-4c14-bd72-7a43897ab40d_primer_detection.csv",
-        "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.primertrimmed.rg.sorted.bam",
-        "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.primertrimmed.rg.sorted.bam.bai",
-        "ncov2019-artic/output_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.consensus.fa",
-        "ncov2019-artic/output_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.preconsensus.fa",
-        "ncov2019-artic/output_plots/e80f3c63-d139-4c14-bd72-7a43897ab40d.depth.png",
-        "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.typing.csv",
-        "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.variants.csv",
-        "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.csq.vcf",
-        "ncov2019-artic/output_variants/e80f3c63-d139-4c14-bd72-7a43897ab40d.pass.vcf.gz",
-        "ncov2019-artic/output_variants/e80f3c63-d139-4c14-bd72-7a43897ab40d.pass.vcf.gz.tbi",
-        "reheadered-fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta"
+        {
+            "file": "contamination_removal/cleaned_fastq/e80f3c63-d139-4c14-bd72-7a43897ab40d.fastq.gz",
+            "type": "fastq/cleaned-sequence-data"
+        },
+        {
+            "file": "contamination_removal/counting/e80f3c63-d139-4c14-bd72-7a43897ab40d.txt",
+            "type": "txt/cleaned-sequence-count"
+        },
+        {
+            "file": "contamination_removal/e80f3c63-d139-4c14-bd72-7a43897ab40d_contamination_removal.csv",
+            "type": "csv/cleaned-sequence-count"
+        },
+        {
+            "file": "fastqc/e80f3c63-d139-4c14-bd72-7a43897ab40d_fastqc.zip",
+            "type": "fastqc/qc"
+        },
+        {
+            "file": "primer_autodetection/e80f3c63-d139-4c14-bd72-7a43897ab40d_primer_data.csv",
+            "type": "csv/primer-data"
+        },
+        {
+            "file": "primer_autodetection/e80f3c63-d139-4c14-bd72-7a43897ab40d_primer_detection.csv",
+            "type": "csv/primer-detection"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.primertrimmed.rg.sorted.bam",
+            "type": "bam/final"
+        },
+        {
+            "file": "ncov2019-artic/output_bam/e80f3c63-d139-4c14-bd72-7a43897ab40d.primertrimmed.rg.sorted.bam.bai",
+            "type": "bai/final"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.consensus.fa",
+            "type": "fasta/consensus"
+        },
+        {
+            "file": "ncov2019-artic/output_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.preconsensus.fa",
+            "type": "fasta/preconsensus"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.typing.csv",
+            "type": "csv/typing"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.variants.csv",
+            "type": "csv/typing-variants"
+        },
+        {
+            "file": "ncov2019-artic/output_typing/e80f3c63-d139-4c14-bd72-7a43897ab40d.csq.vcf",
+            "type": "vcf/typing-consequences"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/e80f3c63-d139-4c14-bd72-7a43897ab40d.pass.vcf.gz",
+            "type": "vcf/final"
+        },
+        {
+            "file": "ncov2019-artic/output_variants/e80f3c63-d139-4c14-bd72-7a43897ab40d.pass.vcf.gz.tbi",
+            "type": "tbi/final"
+        },
+        {
+            "file": "ncov2019-artic/output_plots/e80f3c63-d139-4c14-bd72-7a43897ab40d.depth.png",
+            "type": "png/qc"
+        },
+        {
+            "file": "reheadered-fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta",
+            "type": "fasta/final"
+        }
     ]
 }

--- a/tests/test_data/pipeline_results_files/resultfiles_unknown.json
+++ b/tests/test_data/pipeline_results_files/resultfiles_unknown.json
@@ -1,17 +1,32 @@
 {
     "0774181d-fb20-4a73-b887-38af7eda9b38": [
-        "reheadered-fasta/0774181d-fb20-4a73-b887-38af7eda9b38.fasta"
+        {
+            "file": "reheadered-fasta/0774181d-fb20-4a73-b887-38af7eda9b38.fasta",
+            "type": "fasta/final"
+        }
     ],
     "56a63f60-764d-4fc7-8764-a46023cbe324": [
-        "reheadered-fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta"
+        {
+            "file": "reheadered-fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta",
+            "type": "fasta/final"
+        }
     ],
     "985347c5-ff6a-454c-ac34-bc353d05dd70": [
-        "reheadered-fasta/985347c5-ff6a-454c-ac34-bc353d05dd70.fasta"
+        {
+            "file": "reheadered-fasta/985347c5-ff6a-454c-ac34-bc353d05dd70.fasta",
+            "type": "fasta/final"
+        }
     ],
     "a0951432-cd94-45b5-96d5-b721c037a451": [
-        "reheadered-fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta"
+        {
+            "file": "reheadered-fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta",
+            "type": "fasta/final"
+        }
     ],
     "e80f3c63-d139-4c14-bd72-7a43897ab40d": [
-        "reheadered-fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta"
+        {
+            "file": "reheadered-fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta",
+            "type": "fasta/final"
+        }
     ]
 }

--- a/tests/util/test_slugs.py
+++ b/tests/util/test_slugs.py
@@ -1,0 +1,37 @@
+import pytest
+
+from scripts.util.slugs import get_file_with_type, FileType
+
+
+@pytest.mark.parametrize("output_path", ["/", "s3://my_bucket/"])
+@pytest.mark.parametrize("inner_dirs", [["a"], ["a", "b"], ["a", "b", "c"]])
+@pytest.mark.parametrize(
+    "filetypes",
+    [
+        [FileType(".bam", "bam/final"), FileType(".bam.bai", "bai/final")],
+        [FileType(".fastq", "fastq/cleaned")],
+    ],
+)
+@pytest.mark.parametrize("sample_id", ["roger", "clio"])
+def test_get_file_with_type(
+    output_path,
+    inner_dirs,
+    filetypes,
+    sample_id,
+):
+    sample_files = get_file_with_type(
+        output_path=output_path,
+        inner_dirs=inner_dirs,
+        filetypes=filetypes,
+        sample_id=sample_id,
+    )
+
+    expected_files = []
+    for ft in filetypes:
+        expected_files.append(
+            {
+                "file": f"{output_path}{'/'.join(inner_dirs)}/{sample_id}{ft.extension}",
+                "type": f"{ft.filetype}",
+            }
+        )
+    assert sample_files == expected_files

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -13,7 +13,7 @@ def assert_files_are_equal(file1: Path, file2: Path) -> None:
             assert content_1 == content_2
 
 
-def assert_dataframes_are_equal(file1: Path, file2: Path, sortby_col: str) -> None:
+def assert_csvs_are_equal(file1: Path, file2: Path, sortby_col: str) -> None:
     df = pd.read_csv(file1)
     df_exp = pd.read_csv(file2)
 
@@ -24,7 +24,7 @@ def assert_dataframes_are_equal(file1: Path, file2: Path, sortby_col: str) -> No
     # sort columns by column name
     df_sorted = df_sorted.reindex(columns=sorted(df_sorted.columns))
     df_exp_sorted = df_exp_sorted.reindex(columns=sorted(df_exp_sorted.columns))
-    assert_frame_equal(df_sorted, df_exp_sorted)
+    assert_frame_equal(df_sorted.reset_index(drop=True), df_exp_sorted.reset_index(drop=True))
 
 
 def json_to_dict(input_path: Path) -> Dict:


### PR DESCRIPTION
This PR has not yet been merged due to the 24/11 release.

**UPDATE**
`type` has changed. See conversation below. 
@cramshaw I replaced `png/coverage` with `png/qc` as those png files are ncov qc plots.

See: https://confluence.congenica.net/pages/viewpage.action?spaceKey=PSG&title=Pipeline+Results 

```
Example



{
  "d96512bc-94d2-4b19-a311-a2da98a2aa95": [{
    "type": "sars-cov-2:fasta",
    "file": "reheaded-fasta/d96512bc-94d2-4b19-a311-a2da98a2aa95.fasta"
   },
   {
     "type": "sars-cov-2:bam",
     "file": "d96512bc-94d2-4b19-a311-a2da98a2aa95.bam"
   },
   {
     "type": "sars-cov-2:vcf",
     "file": "d96512bc-94d2-4b19-a311-a2da98a2aa95.vcf"
   }],
   "41995a81-1420-4b9c-8305-792067f11198": [{
     "type": "sars-cov-2:fasta",
     "file": "reheaded-fasta/41995a81-1420-4b9c-8305-792067 f11198.fasta"
    },
    {
     "type": "sars-cov-2:bam",
     "file": "41995a81-1420-4b9c-8305-792067 f11198.bam"
    },
    {
      "type": "sars-cov-2:vcf",
      "file": "pagolin/41995a81-1420-4b9c-8305-792067 f11198.vcf"
    }]
}
```