### PR TITLE
Pin openjdk version in conda as Nextflow complains:

### DIFF
--- a/docker/Dockerfile.ncov2019-artic-nf-illumina
+++ b/docker/Dockerfile.ncov2019-artic-nf-illumina
@@ -9,7 +9,7 @@ COPY docker/ncov2019-artic-nf_extras.yml /extras.yml
 # Also reinstall packages to pinned versions, as the conda-selected downgraded ones fail to run
 RUN mamba env create -f /environment.yml \
   && mamba env update -f /extras.yml -n artic-ncov2019-illumina \
-  && mamba install -y -c conda-forge -c bioconda cutadapt==3.1 dnaio==0.4.4 -n artic-ncov2019-illumina \
+  && mamba install -y -c conda-forge -c bioconda cutadapt==3.1 dnaio==0.4.4 openjdk==11.0.8 -n artic-ncov2019-illumina \
   && conda clean --all -y
 
 

--- a/docker/Dockerfile.ncov2019-artic-nf-nanopore
+++ b/docker/Dockerfile.ncov2019-artic-nf-nanopore
@@ -9,7 +9,7 @@ COPY docker/ncov2019-artic-nf_extras.yml /extras.yml
 # Also reinstall these two packages to their latest version, as the conda-selected downgraded ones fail to run
 RUN mamba env create -f /environment.yml \
   && mamba env update -f /extras.yml -n artic \
-  && mamba install -y -c conda-forge -c bioconda cutadapt==3.1 dnaio==0.4.4 -n artic \
+  && mamba install -y -c conda-forge -c bioconda cutadapt==3.1 dnaio==0.4.4 openjdk==11.0.8 -n artic \
   && conda clean --all -y
 
 


### PR DESCRIPTION
 "CAPSULE EXCEPTION: Could not parse version: 11.0.9.1-internal". This will be completely fix when nextflow is directly installed via Conda