### PR TITLE
change qc to qc_status

### DIFF
--- a/scripts/synthetic/generate_results.py
+++ b/scripts/synthetic/generate_results.py
@@ -23,7 +23,7 @@ STATUS = "STATUS"
 # Synthetic data from TB (fig 2 in https://genomemedicine.biomedcentral.com/articles/10.1186/s13073-020-00817-3)
 PASS = "pass"
 FAIL = "fail"
-QC = "qc"
+QC = "qc_status"
 LINEAGE = "lineage"
 RD = "region_of_difference"
 SYNTHETIC_DATA = [


### PR DESCRIPTION
Naming the column QC breaks all the reports we have for covid. Naming it QC_Status should enable them all to work for both pathogens.