### PR TITLE
PSG-1874: run ncov2019-artic-nf using gff and yaml typing annotions

### DIFF
--- a/data/sars_cov_2/ncov2019-artic-nf/MN908947.3.gff
+++ b/data/sars_cov_2/ncov2019-artic-nf/MN908947.3.gff
@@ -1,0 +1,69 @@
+##gff-version 3
+##sequence-region   MN908947.3 1 29903
+#!genome-build ENA ASM985889v3
+#!genome-version ASM985889v3
+#!genome-date 2020-01
+#!genome-build-accession NCBI:GCA_009858895.3
+MN908947.3	ASM985889v3	region	1	29903	.	.	.	ID=region:MN908947.3;Alias=NC_045512.2,NC_045512v2
+####
+MN908947.3	ensembl	gene	266	13483	.	+	.	ID=gene:ENSSASG00005000003;Name=ORF1ab;biotype=protein_coding;description=ORF1a polyprotein%3BORF1ab polyprotein [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740578];gene_id=ENSSASG00005000003;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	266	13483	.	+	.	ID=transcript:ENSSAST00005000003;Parent=gene:ENSSASG00005000003;Name=ORF1a;biotype=protein_coding;transcript_id=ENSSAST00005000003;version=1
+MN908947.3	ensembl	exon	266	13483	.	+	.	Parent=transcript:ENSSAST00005000003;Name=ENSSASE00005000003;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000003;rank=1;version=1
+MN908947.3	ensembl	CDS	266	13483	.	+	0	ID=CDS:ENSSASP00005000003;Parent=transcript:ENSSAST00005000003;protein_id=ENSSASP00005000003
+####
+MN908947.3	ensembl	gene	266	21555	.	+	.	ID=gene:ENSSASG00005000002;Name=ORF1ab;biotype=protein_coding;description=ORF1a polyprotein%3BORF1ab polyprotein [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740578];gene_id=ENSSASG00005000002;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	266	21555	.	+	.	ID=transcript:ENSSAST00005000002;Parent=gene:ENSSASG00005000002;Name=ORF1ab;biotype=protein_coding;transcript_id=ENSSAST00005000002;version=1
+MN908947.3	ensembl	exon	266	21555	.	+	.	Parent=transcript:ENSSAST00005000002;Name=ENSSASE00005000002;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000002;rank=1;version=1
+MN908947.3	ensembl	CDS	266	21555	.	+	0	ID=CDS:ENSSASP00005000002;Parent=transcript:ENSSAST00005000002;protein_id=ENSSASP00005000002
+####
+MN908947.3	ensembl	gene	21563	25384	.	+	.	ID=gene:ENSSASG00005000004;Name=S;biotype=protein_coding;description=surface glycoprotein [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740568];gene_id=ENSSASG00005000004;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	21563	25384	.	+	.	ID=transcript:ENSSAST00005000004;Parent=gene:ENSSASG00005000004;Name=S;biotype=protein_coding;transcript_id=ENSSAST00005000004;version=1
+MN908947.3	ensembl	exon	21563	25384	.	+	.	Parent=transcript:ENSSAST00005000004;Name=ENSSASE00005000004;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000004;rank=1;version=1
+MN908947.3	ensembl	CDS	21563	25384	.	+	0	ID=CDS:ENSSASP00005000004;Parent=transcript:ENSSAST00005000004;protein_id=ENSSASP00005000004
+####
+MN908947.3	ensembl	gene	25393	26220	.	+	.	ID=gene:ENSSASG00005000006;Name=ORF3a;biotype=protein_coding;description=ORF3a protein [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740569];gene_id=ENSSASG00005000006;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	25393	26220	.	+	.	ID=transcript:ENSSAST00005000006;Parent=gene:ENSSASG00005000006;Name=ORF3a;biotype=protein_coding;transcript_id=ENSSAST00005000006;version=1
+MN908947.3	ensembl	exon	25393	26220	.	+	.	Parent=transcript:ENSSAST00005000006;Name=ENSSASE00005000006;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000006;rank=1;version=1
+MN908947.3	ensembl	CDS	25393	26220	.	+	0	ID=CDS:ENSSASP00005000006;Parent=transcript:ENSSAST00005000006;protein_id=ENSSASP00005000006
+####
+MN908947.3	ensembl	gene	26245	26472	.	+	.	ID=gene:ENSSASG00005000010;Name=E;biotype=protein_coding;description=envelope protein [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740570];gene_id=ENSSASG00005000010;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	26245	26472	.	+	.	ID=transcript:ENSSAST00005000010;Parent=gene:ENSSASG00005000010;Name=E;biotype=protein_coding;transcript_id=ENSSAST00005000010;version=1
+MN908947.3	ensembl	exon	26245	26472	.	+	.	Parent=transcript:ENSSAST00005000010;Name=ENSSASE00005000010;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000010;rank=1;version=1
+MN908947.3	ensembl	CDS	26245	26472	.	+	0	ID=CDS:ENSSASP00005000010;Parent=transcript:ENSSAST00005000010;protein_id=ENSSASP00005000010
+####
+MN908947.3	ensembl	gene	26523	27191	.	+	.	ID=gene:ENSSASG00005000007;Name=M;biotype=protein_coding;description=membrane glycoprotein [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740571];gene_id=ENSSASG00005000007;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	26523	27191	.	+	.	ID=transcript:ENSSAST00005000007;Parent=gene:ENSSASG00005000007;Name=M;biotype=protein_coding;transcript_id=ENSSAST00005000007;version=1
+MN908947.3	ensembl	exon	26523	27191	.	+	.	Parent=transcript:ENSSAST00005000007;Name=ENSSASE00005000007;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000007;rank=1;version=1
+MN908947.3	ensembl	CDS	26523	27191	.	+	0	ID=CDS:ENSSASP00005000007;Parent=transcript:ENSSAST00005000007;protein_id=ENSSASP00005000007
+####
+MN908947.3	ensembl	gene	27202	27387	.	+	.	ID=gene:ENSSASG00005000011;Name=ORF6;biotype=protein_coding;description=ORF6 protein [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740572];gene_id=ENSSASG00005000011;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	27202	27387	.	+	.	ID=transcript:ENSSAST00005000011;Parent=gene:ENSSASG00005000011;Name=ORF6;biotype=protein_coding;transcript_id=ENSSAST00005000011;version=1
+MN908947.3	ensembl	exon	27202	27387	.	+	.	Parent=transcript:ENSSAST00005000011;Name=ENSSASE00005000011;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000011;rank=1;version=1
+MN908947.3	ensembl	CDS	27202	27387	.	+	0	ID=CDS:ENSSASP00005000011;Parent=transcript:ENSSAST00005000011;protein_id=ENSSASP00005000011
+####
+MN908947.3	ensembl	gene	27394	27759	.	+	.	ID=gene:ENSSASG00005000009;Name=ORF7a;biotype=protein_coding;description=ORF7a protein [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740573];gene_id=ENSSASG00005000009;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	27394	27759	.	+	.	ID=transcript:ENSSAST00005000009;Parent=gene:ENSSASG00005000009;Name=ORF7a;biotype=protein_coding;transcript_id=ENSSAST00005000009;version=1
+MN908947.3	ensembl	exon	27394	27759	.	+	.	Parent=transcript:ENSSAST00005000009;Name=ENSSASE00005000009;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000009;rank=1;version=1
+MN908947.3	ensembl	CDS	27394	27759	.	+	0	ID=CDS:ENSSASP00005000009;Parent=transcript:ENSSAST00005000009;protein_id=ENSSASP00005000009
+####
+MN908947.3	ensembl	gene	27756	27887	.	+	.	ID=gene:ENSSASG00005000012;Name=ORF7b;biotype=protein_coding;description=ORF7b [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740574];gene_id=ENSSASG00005000012;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	27756	27887	.	+	.	ID=transcript:ENSSAST00005000012;Parent=gene:ENSSASG00005000012;Name=ORF7b;biotype=protein_coding;transcript_id=ENSSAST00005000012;version=1
+MN908947.3	ensembl	exon	27756	27887	.	+	.	Parent=transcript:ENSSAST00005000012;Name=ENSSASE00005000012;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000012;rank=1;version=1
+MN908947.3	ensembl	CDS	27756	27887	.	+	0	ID=CDS:ENSSASP00005000012;Parent=transcript:ENSSAST00005000012;protein_id=ENSSASP00005000012
+####
+MN908947.3	ensembl	gene	27894	28259	.	+	.	ID=gene:ENSSASG00005000008;Name=ORF8;biotype=protein_coding;description=ORF8 protein [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740577];gene_id=ENSSASG00005000008;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	27894	28259	.	+	.	ID=transcript:ENSSAST00005000008;Parent=gene:ENSSASG00005000008;Name=ORF8;biotype=protein_coding;transcript_id=ENSSAST00005000008;version=1
+MN908947.3	ensembl	exon	27894	28259	.	+	.	Parent=transcript:ENSSAST00005000008;Name=ENSSASE00005000008;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000008;rank=1;version=1
+MN908947.3	ensembl	CDS	27894	28259	.	+	0	ID=CDS:ENSSASP00005000008;Parent=transcript:ENSSAST00005000008;protein_id=ENSSASP00005000008
+####
+MN908947.3	ensembl	gene	28274	29533	.	+	.	ID=gene:ENSSASG00005000005;Name=N;biotype=protein_coding;description=nucleocapsid phosphoprotein [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740575];gene_id=ENSSASG00005000005;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	28274	29533	.	+	.	ID=transcript:ENSSAST00005000005;Parent=gene:ENSSASG00005000005;Name=N;biotype=protein_coding;transcript_id=ENSSAST00005000005;version=1
+MN908947.3	ensembl	exon	28274	29533	.	+	.	Parent=transcript:ENSSAST00005000005;Name=ENSSASE00005000005;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000005;rank=1;version=1
+MN908947.3	ensembl	CDS	28274	29533	.	+	0	ID=CDS:ENSSASP00005000005;Parent=transcript:ENSSAST00005000005;protein_id=ENSSASP00005000005
+####
+MN908947.3	ensembl	gene	29558	29674	.	+	.	ID=gene:ENSSASG00005000013;Name=ORF10;biotype=protein_coding;description=ORF10 protein [Source:NCBI gene (formerly Entrezgene)%3BAcc:43740576];gene_id=ENSSASG00005000013;logic_name=ensembl_covid;version=1
+MN908947.3	ensembl	mRNA	29558	29674	.	+	.	ID=transcript:ENSSAST00005000013;Parent=gene:ENSSASG00005000013;Name=ORF10;biotype=protein_coding;transcript_id=ENSSAST00005000013;version=1
+MN908947.3	ensembl	exon	29558	29674	.	+	.	Parent=transcript:ENSSAST00005000013;Name=ENSSASE00005000013;constitutive=1;ensembl_end_phase=0;ensembl_phase=0;exon_id=ENSSASE00005000013;rank=1;version=1
+MN908947.3	ensembl	CDS	29558	29674	.	+	0	ID=CDS:ENSSASP00005000013;Parent=transcript:ENSSAST00005000013;protein_id=ENSSASP00005000013
+####
+

--- a/data/sars_cov_2/ncov2019-artic-nf/SARS-CoV-2.types.yaml
+++ b/data/sars_cov_2/ncov2019-artic-nf/SARS-CoV-2.types.yaml
@@ -1,0 +1,72 @@
+VOC-202012/01:
+  # https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/947048/Technical_Briefing_VOC_SH_NJL2_SH2.pdf
+  # Table 1
+  coverage: 0.7 # Proportion of found variants to call a type
+  variants:
+    S:          # Gene name
+      - IHV68I  # AA-space type-defining mutation
+      - VY143V
+      - N501Y
+      - A570D
+      - P681H
+      - T716I
+      - S982A
+      - D1118H
+
+    ORF1ab:
+      - T1001I
+      - A1708D
+      - I2230T
+      - LSGF3674L
+
+    ORF8:
+      - Q27*
+      - R52I
+      - Y73C
+
+    N:
+      - D3L
+      - S235F
+
+N501Y.V2:
+  # Note not a complete set of type defining mutations but covers triple spike variants
+  coverage: 0.7
+  variants:
+    S:
+      - D80A
+      - R246I
+      - K417N
+      - E484K
+      - N501Y
+      - D614G
+      - A701V
+
+    E:
+      - P71L
+    N:
+      - T205I
+
+    ORF3a:
+      - Q57H
+      - S171L
+
+    ORF1ab:
+      - T265I
+      - K1655N
+      - H2799Y
+      - S2900L
+      - K3353R
+      - M3655I
+
+N501Y:
+  coverage: 1
+  variants:
+    S:
+      - N501Y
+
+D614G:
+  coverage: 1
+  variants:
+    S:
+      - D614G
+

--- a/docker/Dockerfile.ncov2019-artic-nf-illumina
+++ b/docker/Dockerfile.ncov2019-artic-nf-illumina
@@ -27,6 +27,7 @@ ENV PATH=/ncov2019-artic-nf/bin:/opt/conda/envs/custom_env/bin:$PATH
 ARG pathogen
 COPY docker/${pathogen}/ncov.deps psga/${pathogen}/ncov-illumina.config psga/${pathogen}/ncov-common.config /
 COPY data/${pathogen}/primer_schemes /primer_schemes
+COPY data/${pathogen}/ncov2019-artic-nf/* /
 
 # install awscli here because the conda version requires a much more updated Python version
 RUN . /ncov.deps \

--- a/docker/Dockerfile.ncov2019-artic-nf-nanopore
+++ b/docker/Dockerfile.ncov2019-artic-nf-nanopore
@@ -34,6 +34,7 @@ RUN medaka tools download_models \
 ARG pathogen
 COPY docker/${pathogen}/ncov.deps psga/${pathogen}/ncov-nanopore.config psga/${pathogen}/ncov-common.config /
 COPY data/${pathogen}/primer_schemes /primer_schemes
+COPY data/${pathogen}/ncov2019-artic-nf/* /
 
 RUN . /ncov.deps \
   && pip install awscli==1.20.50 \

--- a/psga/sars_cov_2/nextflow.config
+++ b/psga/sars_cov_2/nextflow.config
@@ -38,6 +38,8 @@ params {
     // read-it-and-keep reference genome fasta without the poly-A tail
     rik_ref_genome_fasta = "/MN908947.3.no_poly_A.fa"
     fastqc_limits = "/limits.txt"
+    ncov2019_artic_nf_typing_gff = "/MN908947.3.gff"
+    ncov2019_artic_nf_typing_yaml = "/SARS-CoV-2.types.yaml"
 
     contamination_removal_empty_csv = "/app/scripts/sars_cov_2/contamination_removal_empty.csv"
     primer_autodetection_empty_csv = "/app/scripts/sars_cov_2/primer_autodetection_empty.csv"


### PR DESCRIPTION
Run ncov with genotyping optional process. 

The addition of these new files and data to the pipeline results.csv and resultfiles.json will be implemented in another ticket.


Examples of information we can extract.

**Illumina**
```
root@sars-cov-2-pipeline-minikube-6cf7cbfc9c-ntg2f:/app/psga# ls /data/output/pipeline_ci_illumina/ncov2019-artic/output_typing/*
/data/output/pipeline_ci_illumina/ncov2019-artic/output_typing/9729bce7-f0a9-4617-b6e0-6145307741d1.csq.vcf
/data/output/pipeline_ci_illumina/ncov2019-artic/output_typing/9729bce7-f0a9-4617-b6e0-6145307741d1.typing.csv
/data/output/pipeline_ci_illumina/ncov2019-artic/output_typing/9729bce7-f0a9-4617-b6e0-6145307741d1.variants.csv

root@sars-cov-2-pipeline-minikube-6cf7cbfc9c-ntg2f:/app/psga# cat /data/output/pipeline_ci_illumina/ncov2019-artic/output_typing/*.csv
# typing.csv
sampleID,type,num_matching_vars,num_missing_vars,type_coverage,found_vars,missing_vars,additional_vars
9729bce7-f0a9-4617-b6e0-6145307741d1,D614G,1,0,1.0,S.D614G,,ORF1ab.D691N;ORF1ab.Syn.924F;ORF1ab.A1306S;ORF1ab.N1555D;ORF1ab.P2046L;ORF1ab.P2287S;ORF1ab.Syn.2907D;ORF1ab.V2930L;ORF1ab.T3255I;ORF1ab.Syn.3585L;ORF1ab.T3646A;ORF1ab.Syn.3689V;ORF1ab.R3993H;ORF1ab.Syn.4715L;ORF1ab.Syn.5062A;ORF1ab.H5401Y;ORF1ab.R5689I;ORF1ab.Syn.6319L;ORF1ab.S6512I;S.T19R;S.EFR156G;S.P681R;S.D950N;ORF3a.S26L;M.I82T;ORF7a.V82A;ORF7a.T120I;ORF7b.T40I;ORF8.LDF118L;N.D63G;N.R203M;N.G215C;N.D377Y

# variants.csv
sampleID,gene,aa_var,dna_var
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,D691N,G2336A
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,Syn.924F,C3037T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,A1306S,G4181T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,N1555D,A4928G
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,P2046L,C6402T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,P2287S,C7124T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,Syn.2907D,C8986T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,V2930L,G9053T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,T3255I,C10029T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,Syn.3585L,C11020T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,T3646A,A11201G
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,Syn.3689V,A11332G
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,R3993H,G12243A
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,Syn.4715L,C14408T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,Syn.5062A,G15451A
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,H5401Y,C16466T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,R5689I,G17331T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,Syn.6319L,C19220T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF1ab,S6512I,G19800T
9729bce7-f0a9-4617-b6e0-6145307741d1,S,T19R,C21618G
9729bce7-f0a9-4617-b6e0-6145307741d1,S,EFR156G,GAGTTCA22028G
9729bce7-f0a9-4617-b6e0-6145307741d1,S,D614G,A23403G
9729bce7-f0a9-4617-b6e0-6145307741d1,S,P681R,C23604G
9729bce7-f0a9-4617-b6e0-6145307741d1,S,D950N,G24410A
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF3a,S26L,C25469T
9729bce7-f0a9-4617-b6e0-6145307741d1,M,I82T,T26767C
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF7a,V82A,T27638C
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF7a,T120I,C27752T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF7b,T40I,C27874T
9729bce7-f0a9-4617-b6e0-6145307741d1,ORF8,LDF118L,AGATTTC28247A
9729bce7-f0a9-4617-b6e0-6145307741d1,N,D63G,A28461G
9729bce7-f0a9-4617-b6e0-6145307741d1,N,R203M,G28881T
9729bce7-f0a9-4617-b6e0-6145307741d1,N,G215C,G28916T
9729bce7-f0a9-4617-b6e0-6145307741d1,N,D377Y,G29402T
```

**ONT**
```
root@sars-cov-2-pipeline-minikube-6cf7cbfc9c-ntg2f:/app/psga# ls /data/output/pipeline_ci_ont/ncov2019-artic/output_typing/*
/data/output/pipeline_ci_ont/ncov2019-artic/output_typing/d3e958b5-0c56-48d6-807b-6a89f61408ce.csq.vcf
/data/output/pipeline_ci_ont/ncov2019-artic/output_typing/d3e958b5-0c56-48d6-807b-6a89f61408ce.typing.csv
/data/output/pipeline_ci_ont/ncov2019-artic/output_typing/d3e958b5-0c56-48d6-807b-6a89f61408ce.variants.csv

root@sars-cov-2-pipeline-minikube-6cf7cbfc9c-ntg2f:/app/psga# cat /data/output/pipeline_ci_ont/ncov2019-artic/output_typing/*.csv
# typing.csv
sampleID,type,num_matching_vars,num_missing_vars,type_coverage,found_vars,missing_vars,additional_vars
d3e958b5-0c56-48d6-807b-6a89f61408ce,D614G,1,0,1.0,S.D614G,,ORF1ab.Syn.216S;ORF1ab.Syn.924F;ORF1ab.Frameshift.958KHLWNLVPLLLLFNLKKSKKKIG*;S.A570D;S.S982A;S.D1118H;ORF8.Q27*;ORF8.R52I;ORF8.Y73C

# variants.csv
sampleID,gene,aa_var,dna_var
d3e958b5-0c56-48d6-807b-6a89f61408ce,ORF1ab,Syn.216S,C913T
d3e958b5-0c56-48d6-807b-6a89f61408ce,ORF1ab,Syn.924F,C3037T
d3e958b5-0c56-48d6-807b-6a89f61408ce,ORF1ab,Frameshift.958KHLWNLVPLLLLFNLKKSKKKIG*,A3138AGC
d3e958b5-0c56-48d6-807b-6a89f61408ce,S,A570D,C23271A
d3e958b5-0c56-48d6-807b-6a89f61408ce,S,D614G,A23403G
d3e958b5-0c56-48d6-807b-6a89f61408ce,S,S982A,T24506G
d3e958b5-0c56-48d6-807b-6a89f61408ce,S,D1118H,G24914C
d3e958b5-0c56-48d6-807b-6a89f61408ce,ORF8,Q27*,C27972T
d3e958b5-0c56-48d6-807b-6a89f61408ce,ORF8,R52I,G28048T
d3e958b5-0c56-48d6-807b-6a89f61408ce,ORF8,Y73C,A28111G
```