### PR TITLE
Pin openjdk version in conda as Nextflow complains: 

### DIFF
--- a/docker/sars_cov_2/ncov2019-artic-nf_extras.yml
+++ b/docker/sars_cov_2/ncov2019-artic-nf_extras.yml
@@ -8,4 +8,5 @@ dependencies:
   - pandas
   - samtools
   - libxcb
+  - openjdk=11.0.8
   - nextflow=21.10.6


### PR DESCRIPTION
"CAPSULE EXCEPTION: Could not parse version: 11.0.9.1-internal". This will be completely fix when nextflow is directly installed via Conda