### PR TITLE
PSG-1886: update synthetic pipeline to run fastqc in its own dedicated docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DOCKER_IMAGE_URI_PATH=566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev
 DOCKER_IMAGE_TAG=1.0.0
 SARS_COV_2=sars_cov_2
+SYNTHETIC=synthetic
 
 # build images per pathogen
 sars-cov-2-images:
@@ -13,4 +14,5 @@ sars-cov-2-images:
 	docker build --build-arg pathogen=${SARS_COV_2} -t ${DOCKER_IMAGE_URI_PATH}/pangolin:${DOCKER_IMAGE_TAG} -f docker/Dockerfile.pangolin .
 
 synthetic-images:
-	docker build --build-arg pathogen=synthetic -t ${DOCKER_IMAGE_URI_PATH}/synthetic-pipeline:${DOCKER_IMAGE_TAG} -f docker/Dockerfile.psga-pipeline .
+	docker build --build-arg pathogen=${SYNTHETIC} -t ${DOCKER_IMAGE_URI_PATH}/synthetic-pipeline:${DOCKER_IMAGE_TAG} -f docker/Dockerfile.psga-pipeline .
+	docker build --build-arg pathogen=${SYNTHETIC} -t ${DOCKER_IMAGE_URI_PATH}/fastqc:${DOCKER_IMAGE_TAG} -f docker/Dockerfile.fastqc .

--- a/data/synthetic/fastqc/limits.txt
+++ b/data/synthetic/fastqc/limits.txt
@@ -1,0 +1,81 @@
+# For each of the modules you can choose to not run that
+# module at all by setting the value below to 1 for the
+# modules you want to remove.
+duplication 		ignore 		1
+kmer 				ignore 		1
+n_content 			ignore 		0
+overrepresented 	ignore 		1
+quality_base 		ignore 		0
+sequence 			ignore 		0
+gc_sequence			ignore 		1
+quality_sequence	ignore		1
+tile				ignore		1
+sequence_length		ignore		1
+adapter				ignore		0
+
+# For the duplication module the value is the percentage
+# remaining after deduplication.  Measured levels below
+# these limits trigger the warning / error.
+duplication	warn	70
+duplication error	50
+
+# For the kmer module the filter is on the -log10 binomial
+# pvalue for the most significant Kmer, so 5 would be
+# 10^-5 = p<0.00001
+kmer	warn	2
+kmer	error	5
+
+# For the N module the filter is on the percentage of Ns
+# at any position in the library
+n_content	warn	5
+n_content	error	20
+
+# For the overrepresented seqs the warn value sets the
+# threshold for the overrepresented sequences to be reported
+# at all as the proportion of the library which must be seen
+# as a single sequence
+overrepresented	warn	0.1
+overrepresented	error	1
+
+# The per base quality filter uses two values, one for the value
+# of the lower quartile, and the other for the value of the
+# median quality.  Failing either of these will trigger the alert
+quality_base_lower	warn	10
+quality_base_lower	error	5
+quality_base_median	warn	25
+quality_base_median	error	20
+
+# The per base sequence content module tests the maximum deviation
+# between A and T or C and G
+sequence	warn	10
+sequence	error	20
+
+# The per sequence GC content tests the maximum deviation between
+# the theoretical distribution and the real distribution
+gc_sequence	warn	15
+gc_sequence	error	30
+
+# The per sequence quality module tests the phred score which is
+# most frequently observed
+quality_sequence	warn	27
+quality_sequence	error	20
+
+# The per tile module tests the maximum phred score loss between
+# and individual tile and the average for that base across all tiles
+tile	warn	5
+tile	error	10
+
+# The sequence length module tests are binary, so the values here
+# simply turn them on or off.  The actual tests warn if you have
+# sequences of different length, and error if you have sequences
+# of zero length.
+
+sequence_length	warn	1
+sequence_length	error	1
+
+# The adapter module's warnings and errors are based on the
+# percentage of reads in the library which have been observed
+# to contain an adapter associated Kmer at any point
+
+adapter	warn	5
+adapter	error	10

--- a/docker/synthetic/fastqc.yml
+++ b/docker/synthetic/fastqc.yml
@@ -1,0 +1,7 @@
+name: fastqc
+channels:
+  - bioconda
+  - conda-forge # required for awscli
+dependencies:
+  - awscli=1.25.92
+  - fastqc=0.11.9

--- a/psga/synthetic/nextflow.config
+++ b/psga/synthetic/nextflow.config
@@ -11,11 +11,16 @@ manifest {
     version = '1.0.0'
 }
 
+params {
+    fastqc_limits = "/limits.txt"
+}
+
 process {
     // default directives
     container = "${env.DOCKER_IMAGE_URI_PATH}/synthetic-pipeline:${env.DOCKER_IMAGE_TAG}"
 
     withName:fastqc {
+        container = "${env.DOCKER_IMAGE_URI_PATH}/fastqc:${env.DOCKER_IMAGE_TAG}"
         errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
     }
 }


### PR DESCRIPTION
This update follows the refactory of the docker images.
Fastqc used to run in the sars-cov-2 and synthetic docker image, but now runs on its own docker image.


NOTE: the synthetic pipeline reuses the fastqc docker image of the sars-cov-2 pipeline. This could not be the case for other pathogens as we might want to have different fastqc versions / limits configs.


Testing: 
```
root@synthetic-pipeline-minikube-5fdb87d78b-wj68g:/app/psga# nextflow run . --run synthetic --sequencing_technology illumina --kit ARTIC_V4 --metadata /data/pipeline_ci_illumina/metadata.csv --output_path /data/output/synthetic
N E X T F L O W  ~  version 22.10.0
Launching `./main.nf` [clever_wozniak] DSL2 - revision: 9ec850e2bd
WARN: K8s namespace provided in the nextflow configuration does not match with pod namespace
[c7/d1968a] Submitted process > psga:organise_metadata_sample_files:check_metadata (metadata.csv)
[13/5ce8d0] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (1 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[73/190e42] Submitted process > psga:fastqc (1 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[88/b3039d] Submitted process > psga:generate_synthetic_output

root@synthetic-pipeline-minikube-5fdb87d78b-wj68g:/app/psga# cat /data/output/synthetic/results.csv 
SAMPLE_ID,STATUS,QC_STATUS,LINEAGE,REGION_OF_DIFFERENCE
9729bce7-f0a9-4617-b6e0-6145307741d1,Completed,fail,3,RD750
```