### PR TITLE
PSG-2426: add contaminated reads column to sars-cov-2 config

### DIFF
--- a/psga/config/psga-schema-sars-cov-2.yaml
+++ b/psga/config/psga-schema-sars-cov-2.yaml
@@ -293,6 +293,13 @@ output_fields:
     validation_rules:
       - rule_type: not_null
 
+  - field_name: CONTAMINATED_READS
+    field_type: number
+    required: true
+    validation_rules:
+      - rule_type: integer
+      - rule_type: not_null
+
   - field_name: PRIMER_INPUT
     field_type: string
     required: true


### PR DESCRIPTION
Current columns in results.csv: 
```
SAMPLE_ID,STATUS,CONTAMINATED_READS,PRIMER_DETECTED,PRIMER_NUMREADS,PRIMER_UNIQUE_NUMREADS,PRIMER_COVERAGE,PRIMER_INPUT,NCOV_PCT_N_BASES,NCOV_PCT_COVERED_BASES,NCOV_LONGEST_NO_N_RUN,NCOV_NUM_ALIGNED_READS,NCOV_QC_PASS,PANGOLIN_LINEAGE,PANGOLIN_CONFLICT,PANGOLIN_AMBIGUITY_SCORE,PANGOLIN_SCORPIO_CALL,PANGOLIN_SCORPIO_SUPPORT,PANGOLIN_SCORPIO_CONFLICT,PANGOLIN_SCORPIO_NOTES,PANGOLIN_PANGO_DESIGNATION_VERSION,PANGOLIN_VERSION,PANGOLIN_SCORPIO_VERSION,PANGOLIN_CONSTELLATION_VERSION,PANGOLIN_IS_DESIGNATED,PANGOLIN_QC_STATUS,PANGOLIN_QC_NOTES,PANGOLIN_NOTE
```

Columns in config: 
```
psga-schema-sars-cov-2.yaml:  - field_name: sample_id
psga-schema-sars-cov-2.yaml:  - field_name: SAMPLE_ID
psga-schema-sars-cov-2.yaml:  - field_name: STATUS
psga-schema-sars-cov-2.yaml:  - field_name: CONTAMINATED_READS
psga-schema-sars-cov-2.yaml:  - field_name: PRIMER_INPUT
psga-schema-sars-cov-2.yaml:  - field_name: PRIMER_DETECTED
psga-schema-sars-cov-2.yaml:  - field_name: PRIMER_NUMREADS
psga-schema-sars-cov-2.yaml:  - field_name: PRIMER_UNIQUE_NUMREADS
psga-schema-sars-cov-2.yaml:  - field_name: PRIMER_COVERAGE
psga-schema-sars-cov-2.yaml:  - field_name: NCOV_PCT_N_BASES
psga-schema-sars-cov-2.yaml:  - field_name: NCOV_PCT_COVERED_BASES
psga-schema-sars-cov-2.yaml:  - field_name: NCOV_LONGEST_NO_N_RUN
psga-schema-sars-cov-2.yaml:  - field_name: NCOV_NUM_ALIGNED_READS
psga-schema-sars-cov-2.yaml:  - field_name: NCOV_QC_PASS
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_LINEAGE
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_CONFLICT
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_AMBIGUITY_SCORE
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_SCORPIO_CALL
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_SCORPIO_SUPPORT
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_SCORPIO_CONFLICT
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_SCORPIO_NOTES
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_PANGO_DESIGNATION_VERSION
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_VERSION
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_SCORPIO_VERSION
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_CONSTELLATION_VERSION
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_IS_DESIGNATED
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_QC_STATUS
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_QC_NOTES
psga-schema-sars-cov-2.yaml:  - field_name: PANGOLIN_NOTE
```