### PR TITLE
PSG-2607: amend command `bactopia datasets`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-DOCKER_IMAGE_URI_PATH=566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev
-BACTOPIA_BASE_IMAGE_URI_PATH=566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod
+DOCKER_IMAGE_URI_PATH=566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod
 DOCKER_IMAGE_TAG=dev_latest
 SARS_COV_2=sars_cov_2
 SYNTHETIC=synthetic
@@ -7,7 +6,7 @@ S_AUREUS=s_aureus
 
 # build base images
 bactopia-base-image:
-	docker build -t ${BACTOPIA_BASE_IMAGE_URI_PATH}/bactopia:${DOCKER_IMAGE_TAG} -f docker/Dockerfile.bactopia .
+	docker build -t ${DOCKER_IMAGE_URI_PATH}/bactopia:${DOCKER_IMAGE_TAG} -f docker/Dockerfile.bactopia .
 
 # build images per pathogen
 sars-cov-2-images:

--- a/docker/Dockerfile.s-aureus
+++ b/docker/Dockerfile.s-aureus
@@ -2,8 +2,11 @@ FROM 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod/bactopi
 
 ARG pathogen
 
-# This command takes about 1hr to run
-RUN bactopia datasets --species "Staphylococcus aureus" --include_genus
+# `bactopia datasets` installs every datasets for the specified species.
+# The following command takes about 1hr to run: bactopia datasets --species "Staphylococcus aureus"
+# Do not include `--include_genus` as otherwise the reference genomes for species in the same genus are also installed
+# `--limit 0` forces the downloading of all reference genomes and not a random subsampling of up to 1000. This makes results predictable
+RUN bactopia datasets --species "Staphylococcus aureus" --limit 0
 
 COPY docker/${pathogen}/${pathogen}.yml /requirements.yml
-mamba env update -n base -f requirements.yml
+RUN mamba env update -n base -f requirements.yml

--- a/minikube/deploy_s_aureus_pipeline.yaml
+++ b/minikube/deploy_s_aureus_pipeline.yaml
@@ -23,7 +23,7 @@ spec:
                 values:
                 - "true"
       containers:
-      - image: 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev/s-aureus-pipeline:1.0.0  # run the head pod
+      - image: 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod/s-aureus-pipeline:dev_latest
         name: s-aureus-pipeline-minikube
         command:
         - /bin/bash
@@ -33,9 +33,9 @@ spec:
         imagePullPolicy: Never
         env:
         - name: DOCKER_IMAGE_URI_PATH
-          value: '566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev'
+          value: '566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod'
         - name: DOCKER_IMAGE_TAG
-          value: '1.0.0'
+          value: 'dev_latest'
         - name: AWS_MAX_CONNECTIONS
           value: '20'
         - name: AWS_MAX_PARALLEL_TRANSFERS

--- a/minikube/deploy_sars_cov_2_pipeline.yaml
+++ b/minikube/deploy_sars_cov_2_pipeline.yaml
@@ -23,7 +23,7 @@ spec:
                 values:
                 - "true"
       containers:
-      - image: 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev/sars-cov-2-pipeline:dev_latest
+      - image: 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod/sars-cov-2-pipeline:dev_latest
         name: sars-cov-2-pipeline-minikube
         command:
         - /bin/bash
@@ -33,7 +33,7 @@ spec:
         imagePullPolicy: Never
         env:
         - name: DOCKER_IMAGE_URI_PATH
-          value: '566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev'
+          value: '566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod'
         - name: DOCKER_IMAGE_TAG
           value: 'dev_latest'
         - name: SCRATCH

--- a/minikube/deploy_synthetic_pipeline.yaml
+++ b/minikube/deploy_synthetic_pipeline.yaml
@@ -23,7 +23,7 @@ spec:
                 values:
                 - "true"
       containers:
-      - image: 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev/synthetic-pipeline:dev_latest
+      - image: 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod/synthetic-pipeline:dev_latest
         name: synthetic-pipeline-minikube
         command:
         - /bin/bash
@@ -33,7 +33,7 @@ spec:
         imagePullPolicy: Never
         env:
         - name: DOCKER_IMAGE_URI_PATH
-          value: '566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-dev'
+          value: '566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod'
         - name: DOCKER_IMAGE_TAG
           value: 'dev_latest'
         - name: AWS_MAX_CONNECTIONS


### PR DESCRIPTION
Changes:
1. do not download reference genomes of species sharing the same genus of S-Aureus
2. remove subsampling and fetch all reference genomes for that pathogen
3. fix mamba command
4. (minor) update docker image URI

```
2023-01-23 15:49:04:root:INFO - Staphylococcus aureus verified in ENA Taxonomy database
2023-01-23 15:49:04:root:INFO - Setting up pre-computed Genbank/Refseq minmer datasets
2023-01-23 15:53:53:root:INFO - Setting up antimicrobial resistance datasets
2023-01-23 15:53:53:root:INFO - Setting up latest AMRFinder+ database
2023-01-23 15:54:48:root:INFO - AMRFinder+ database saved to ./datasets/antimicrobial-resistance/amrfinderdb.tar.gz
2023-01-23 15:54:48:root:INFO - Setting up MLST datasets
2023-01-23 15:54:48:root:INFO - Setting up default MLST schema for Staphylococcus aureus
2023-01-23 15:55:20:root:INFO - Creating BLAST MLST dataset
2023-01-23 15:55:20:root:INFO - Setting up custom Prokka proteins
2023-01-23 15:55:20:root:INFO - Setting up custom Prokka proteins for Staphylococcus aureus
2023-01-23 15:55:20:root:INFO - Downloading genomes (assembly level: complete)
2023-01-23 16:22:49:root:INFO - Processing 932 Genbank files
2023-01-23 16:28:20:root:INFO - Median genome size: 2832714 (n=932)
2023-01-23 16:28:20:root:INFO - Running CD-HIT on 2485866 proteins
2023-01-23 16:33:03:root:INFO - Writing summary of available datasets
```

Testing:
```
Integration tests processed correctly.
Further documentation on ticket
```