### PR TITLE
PSG-2503: add htstools docker image containing htslib, samtools and bcftools

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -20,6 +20,8 @@ jobs:
           - name: sars-cov-2-pipeline
             dockerfile: Dockerfile.psga-pipeline
             pathogen: sars_cov_2
+          - name: htstools
+            pathogen: sars_cov_2
           - name: fastqc
             pathogen: sars_cov_2
           - name: read-it-and-keep

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ bactopia-base-image:
 # build images per pathogen
 sars-cov-2-images:
 	docker build --build-arg pathogen=${SARS_COV_2} -t ${DOCKER_IMAGE_URI_PATH}/sars-cov-2-pipeline:${DOCKER_IMAGE_TAG} -f docker/Dockerfile.psga-pipeline .
+	docker build --build-arg pathogen=${SARS_COV_2} -t ${DOCKER_IMAGE_URI_PATH}/htstools:${DOCKER_IMAGE_TAG} -f docker/Dockerfile.htstools .
 	docker build --build-arg pathogen=${SARS_COV_2} -t ${DOCKER_IMAGE_URI_PATH}/read-it-and-keep:${DOCKER_IMAGE_TAG} -f docker/Dockerfile.read-it-and-keep .
 	docker build --build-arg pathogen=${SARS_COV_2} -t ${DOCKER_IMAGE_URI_PATH}/fastqc:${DOCKER_IMAGE_TAG} -f docker/Dockerfile.fastqc .
 	docker build --build-arg pathogen=${SARS_COV_2} -t ${DOCKER_IMAGE_URI_PATH}/primer-autodetection:${DOCKER_IMAGE_TAG} -f docker/Dockerfile.primer-autodetection .

--- a/docker/Dockerfile.htstools
+++ b/docker/Dockerfile.htstools
@@ -1,0 +1,14 @@
+FROM condaforge/mambaforge:4.14.0-0 AS condabuild
+
+ARG pathogen
+COPY docker/${pathogen}/htstools.yml /environment.yml
+
+RUN mamba env create -f /environment.yml -n custom_env \
+  && conda clean --all -y
+
+FROM debian:buster-slim
+
+ARG pathogen
+
+COPY --from=condabuild /opt/conda/envs/custom_env /opt/conda/envs/custom_env
+ENV PATH=/opt/conda/envs/custom_env/bin:$PATH

--- a/docker/sars_cov_2/htstools.yml
+++ b/docker/sars_cov_2/htstools.yml
@@ -1,0 +1,9 @@
+name: htstools
+channels:
+  - bioconda
+  - conda-forge # required for awscli
+dependencies:
+  - awscli=1.25.92
+  - htslib=1.16
+  - samtools=1.16.1
+  - bcftools=1.16

--- a/psga/sars_cov_2/nextflow.config
+++ b/psga/sars_cov_2/nextflow.config
@@ -64,7 +64,7 @@ process {
 
     if ( params.sequencing_technology == "illumina" ) {
         withName:bam_to_fastq_illumina {
-            container = "${env.DOCKER_IMAGE_URI_PATH}/ncov2019-artic-nf-illumina:${env.DOCKER_IMAGE_TAG}"
+            container = "${env.DOCKER_IMAGE_URI_PATH}/htstools:${env.DOCKER_IMAGE_TAG}"
             memory = { "${env.PROCESS_MEMORY_HIGH}" as int * 1.MB * task.attempt }
             errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
         }
@@ -85,7 +85,7 @@ process {
         }
     } else if ( params.sequencing_technology == "ont" ) {
         withName:bam_to_fastq_ont {
-            container = "${env.DOCKER_IMAGE_URI_PATH}/ncov2019-artic-nf-nanopore:${env.DOCKER_IMAGE_TAG}"
+            container = "${env.DOCKER_IMAGE_URI_PATH}/htstools:${env.DOCKER_IMAGE_TAG}"
             memory = { "${env.PROCESS_MEMORY_HIGH}" as int * 1.MB * task.attempt }
             errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
         }


### PR DESCRIPTION
This generic and small image (488MB) can be used for a wide range of pipeline tasks.

Note: we need to add a new ECR called `htstools` for this PR.

Testing does not show any difference as expected.