### PR TITLE
PSG-2471: reheader fasta files within ncov process

### DIFF
--- a/psga/common/reheader.nf
+++ b/psga/common/reheader.nf
@@ -1,118 +1,24 @@
 /*
- * Make sure that the extension is *.fa
- */
-process standardise_fasta {
-  tag "${task.index} - ${fasta}"
-  input:
-    path fasta
-
-  output:
-    path "*.consensus.fa"
-
-  shell:
-  '''
-  fasta=!{fasta}
-  mv ${fasta} ${fasta%.*}.consensus.fa
-  '''
-}
-
-/*
  * Reheader a fasta file
  */
 process reheader_fasta {
+  publishDir "${params.output_path}", mode: 'copy', overwrite: true, pattern: 'reheadered_fasta/*.fasta'
+
   tag "${task.index} - ${fasta}"
+
   input:
     path fasta
 
   output:
-    path "*.fasta"
+    path "reheadered_fasta/*.fasta"
 
-  script:
-  """
-  python ${PSGA_ROOT_PATH}/scripts/common/reheader_fasta.py --input-dir . --output-dir .
-  """
-}
+  shell:
+  '''
+  # standardise input fasta before re-headering
+  fasta=!{fasta}
+  mkdir input_dir reheadered_fasta
+  cp ${fasta} input_dir/${fasta%.*}.consensus.fa
 
-process store_reheadered_qc_passed_fasta {
-  tag "${task.index} - ${reheadered_fasta_file}"
-  publishDir "${params.output_path}/reheadered-fasta", mode: 'copy', overwrite: true
-
-  input:
-    tuple val(sample_name), path(reheadered_fasta_file)
-
-  output:
-    path matching_file, emit: ch_qc_passed_fasta
-
-  script:
-    matching_file = "${sample_name}.fasta"
-
-  """
-  """
-}
-
-process store_reheadered_qc_failed_fasta {
-  tag "${task.index} - ${reheadered_fasta_file}"
-  publishDir "${params.output_path}/reheadered-fasta-qc-failed", mode: 'copy', overwrite: true
-
-  input:
-    tuple val(sample_name), path(reheadered_fasta_file)
-
-  output:
-    path matching_file, emit: ch_qc_failed_fasta
-
-  script:
-    matching_file = "${sample_name}.fasta"
-
-  """
-  """
-}
-
-/*
- * Reheader a fasta file and store it.
- * If sequencing_technology is "unknown", input samples are fasta
- * Return the reheadered passed fasta
- */
-workflow reheader {
-    take:
-       ch_samples_fasta
-       ch_samples_passing_qc
-       ch_samples_failing_qc
-    main:
-
-        if ( params.sequencing_technology == "unknown" ) {
-
-            ch_reheadered_fasta = reheader_fasta(standardise_fasta(ch_samples_fasta))
-
-            // extend with the sample name [sample_name, fasta]
-            // there is no QC, so we assume they all passed
-            ch_reheadered_fasta
-                .map{ file -> tuple( file.baseName, file ) }
-                .set{ ch_reheadered_fasta_qc_passed }
-
-        } else {
-
-            ch_reheadered_fasta = reheader_fasta(ch_samples_fasta)
-
-            // extend with the sample name [sample_name, fasta]
-            ch_reheadered_fasta
-                .map{ file -> tuple( file.baseName, file ) }
-                .set{ ch_reheadered_fasta_with_sample_name }
-
-            // join the tuples by sample_name
-            ch_reheadered_fasta_with_sample_name
-                .join(ch_samples_passing_qc)
-                .set{ ch_reheadered_fasta_qc_passed }
-
-            ch_reheadered_fasta_with_sample_name
-                .join(ch_samples_failing_qc)
-                .set{ ch_reheadered_fasta_qc_failed }
-
-            store_reheadered_qc_failed_fasta(ch_reheadered_fasta_qc_failed)
-
-        }
-
-        ch_qc_passed_fasta = store_reheadered_qc_passed_fasta(ch_reheadered_fasta_qc_passed)
-
-    emit:
-        ch_qc_passed_fasta
+  python ${PSGA_ROOT_PATH}/scripts/common/reheader_fasta.py --input-dir input_dir --output-dir reheadered_fasta
+  '''
 }

--- a/psga/sars_cov_2/ncov2019_artic.nf
+++ b/psga/sars_cov_2/ncov2019_artic.nf
@@ -4,14 +4,14 @@
  */
 process ncov2019_artic_nf_pipeline_illumina {
   publishDir "${params.output_path}/ncov2019-artic", mode: 'copy', overwrite: true, pattern: 'output_{bam,fasta,plots,typing,variants}/*'
+  publishDir "${params.output_path}", mode: 'copy', overwrite: true, pattern: 'reheadered_fasta/*.fasta'
 
   tag "${task.index} - ${input_files}"
   input:
     path input_files
 
   output:
-    // retain the qc csv intentionally
-    tuple path("ncov_output/*.qc.csv"), path("output_fasta/*.consensus.fa"), emit: ch_ncov_sample_fasta
+    path "reheadered_fasta/*.fasta", emit: ch_ncov_sample_fasta
     path "ncov_output/*.qc.csv", emit: ch_ncov_qc_csv
     path "output_bam/*.bam*"
     path "output_fasta/*.fa"
@@ -39,6 +39,7 @@ process ncov2019_artic_nf_pipeline_illumina {
   output_plots="output_plots"
   output_typing="output_typing"
   output_variants="output_variants"
+  reheadered_fasta="reheadered_fasta"
 
   # extract the sample name from one of the reads
   sample_id="$(ls *.fastq.gz | head -n 1 | cut -d"_" -f1)"
@@ -67,7 +68,7 @@ process ncov2019_artic_nf_pipeline_illumina {
       -work-dir /tmp \
       -c /ncov-illumina.config
 
-  mkdir -p ${output_bam} ${output_fasta} ${output_plots} ${output_typing} ${output_variants}
+  mkdir -p ${output_bam} ${output_fasta} ${output_plots} ${output_typing} ${output_variants} ${reheadered_fasta}
   mv ${ncov_untrimmed_bam_out_dir}/*.${untrimmed_bam_file_ext} ${output_bam}
   mv ${ncov_trimmed_bam_out_dir}/*.${trimmed_bam_file_ext} ${output_bam}
   mv ${ncov_fasta_out_dir}/*.primertrimmed.consensus.fa ${output_fasta}
@@ -82,6 +83,8 @@ process ncov2019_artic_nf_pipeline_illumina {
   samtools index ${output_bam}/${sample_id}.${untrimmed_bam_file_ext} ${output_bam}/${sample_id}.${untrimmed_bam_file_ext}.bai
   samtools index ${output_bam}/${sample_id}.${trimmed_bam_file_ext} ${output_bam}/${sample_id}.${trimmed_bam_file_ext}.bai
 
+  # reheader fasta file
+  python ${PSGA_ROOT_PATH}/scripts/common/reheader_fasta.py --input-dir ${output_fasta} --output-dir ${reheadered_fasta}
   '''
 }
 
@@ -93,14 +96,14 @@ process ncov2019_artic_nf_pipeline_illumina {
  */
 process ncov2019_artic_nf_pipeline_medaka {
   publishDir "${params.output_path}/ncov2019-artic", mode: 'copy', overwrite: true, pattern: 'output_{bam,fasta,plots,typing,variants}/*'
+  publishDir "${params.output_path}", mode: 'copy', overwrite: true, pattern: 'reheadered_fasta/*.fasta'
 
   tag "${task.index} - ${input_files}"
   input:
     path input_files
 
   output:
-    // retain the qc csv intentionally
-    tuple path("ncov_output/*.qc.csv"), path("output_fasta/*.consensus.fa"), emit: ch_ncov_sample_fasta
+    path "reheadered_fasta/*.fasta", emit: ch_ncov_sample_fasta
     path "ncov_output/*.qc.csv", emit: ch_ncov_qc_csv
     path "output_bam/*.bam*"
     path "output_fasta/*.fa"
@@ -126,6 +129,7 @@ process ncov2019_artic_nf_pipeline_medaka {
   output_plots="output_plots"
   output_typing="output_typing"
   output_variants="output_variants"
+  reheadered_fasta="reheadered_fasta"
 
   # extract the sample name from the fastq file
   sample_id="$(ls *.fastq.gz | head -n 1 | cut -d"." -f1)"
@@ -174,7 +178,7 @@ process ncov2019_artic_nf_pipeline_medaka {
       -work-dir /tmp \
       -c /ncov-nanopore.config
 
-  mkdir -p ${output_bam} ${output_fasta} ${output_plots} ${output_typing} ${output_variants}
+  mkdir -p ${output_bam} ${output_fasta} ${output_plots} ${output_typing} ${output_variants} ${reheadered_fasta}
   mv ${ncov_minion_out_dir}/*${sample_id}.${untrimmed_bam_file_ext} ${output_bam}
   mv ${ncov_minion_out_dir}/*${sample_id}.${trimmed_bam_file_ext} ${output_bam}
   mv ${ncov_minion_out_dir}/*.fasta ${output_fasta}
@@ -219,5 +223,7 @@ process ncov2019_artic_nf_pipeline_medaka {
       cd - > /dev/null
   done
 
+  # reheader fasta file
+  python ${PSGA_ROOT_PATH}/scripts/common/reheader_fasta.py --input-dir ${output_fasta} --output-dir ${reheadered_fasta}
   '''
 }

--- a/psga/sars_cov_2/nextflow.config
+++ b/psga/sars_cov_2/nextflow.config
@@ -102,11 +102,11 @@ process {
             // if the computation for 1 sample dies, do not interrupt the computation for the other samples
             errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
         }
-    }
-
-    withName:reheader_fasta {
-        memory = { "${env.PROCESS_MEMORY_MEDIUM}" as int * 1.MB * task.attempt }
-        errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
+    } else if ( params.sequencing_technology == "unknown" ) {
+        withName:reheader_fasta {
+            memory = { "${env.PROCESS_MEMORY_MEDIUM}" as int * 1.MB * task.attempt }
+            errorStrategy = { (task.exitStatus != 0 && task.attempt <= "${env.PROCESS_MAX_RETRIES}" as int) ? 'retry' : 'ignore' }
+        }
     }
 
     withName:pangolin_pipeline {

--- a/scripts/sars_cov_2/generate_pipeline_results_files.py
+++ b/scripts/sars_cov_2/generate_pipeline_results_files.py
@@ -466,7 +466,7 @@ def get_expected_output_files_per_sample(
         output_files[sample_id].extend(
             get_file_with_type(
                 output_path=output_path,
-                inner_dirs=["reheadered-fasta"],
+                inner_dirs=["reheadered_fasta"],
                 filetypes=[FileType(".fasta", "fasta/final")],
                 sample_id=sample_id,
             )

--- a/tests/test_data/pipeline_results_files/sars_cov_2/resultfiles_illumina.json
+++ b/tests/test_data/pipeline_results_files/sars_cov_2/resultfiles_illumina.json
@@ -147,7 +147,7 @@
             "type": "png/qc"
         },
         {
-            "file": "reheadered-fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta",
+            "file": "reheadered_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta",
             "type": "fasta/final"
         }
     ],
@@ -259,7 +259,7 @@
             "type": "png/qc"
         },
         {
-            "file": "reheadered-fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta",
+            "file": "reheadered_fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta",
             "type": "fasta/final"
         }
     ],
@@ -405,7 +405,7 @@
             "type": "png/qc"
         },
         {
-            "file": "reheadered-fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta",
+            "file": "reheadered_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta",
             "type": "fasta/final"
         }
     ]

--- a/tests/test_data/pipeline_results_files/sars_cov_2/resultfiles_ont.json
+++ b/tests/test_data/pipeline_results_files/sars_cov_2/resultfiles_ont.json
@@ -147,7 +147,7 @@
             "type": "png/qc"
         },
         {
-            "file": "reheadered-fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta",
+            "file": "reheadered_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta",
             "type": "fasta/final"
         }
     ],
@@ -251,7 +251,7 @@
             "type": "png/qc"
         },
         {
-            "file": "reheadered-fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta",
+            "file": "reheadered_fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta",
             "type": "fasta/final"
         }
     ],
@@ -381,7 +381,7 @@
             "type": "png/qc"
         },
         {
-            "file": "reheadered-fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta",
+            "file": "reheadered_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta",
             "type": "fasta/final"
         }
     ]

--- a/tests/test_data/pipeline_results_files/sars_cov_2/resultfiles_unknown.json
+++ b/tests/test_data/pipeline_results_files/sars_cov_2/resultfiles_unknown.json
@@ -1,31 +1,31 @@
 {
     "0774181d-fb20-4a73-b887-38af7eda9b38": [
         {
-            "file": "reheadered-fasta/0774181d-fb20-4a73-b887-38af7eda9b38.fasta",
+            "file": "reheadered_fasta/0774181d-fb20-4a73-b887-38af7eda9b38.fasta",
             "type": "fasta/final"
         }
     ],
     "56a63f60-764d-4fc7-8764-a46023cbe324": [
         {
-            "file": "reheadered-fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta",
+            "file": "reheadered_fasta/56a63f60-764d-4fc7-8764-a46023cbe324.fasta",
             "type": "fasta/final"
         }
     ],
     "985347c5-ff6a-454c-ac34-bc353d05dd70": [
         {
-            "file": "reheadered-fasta/985347c5-ff6a-454c-ac34-bc353d05dd70.fasta",
+            "file": "reheadered_fasta/985347c5-ff6a-454c-ac34-bc353d05dd70.fasta",
             "type": "fasta/final"
         }
     ],
     "a0951432-cd94-45b5-96d5-b721c037a451": [
         {
-            "file": "reheadered-fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta",
+            "file": "reheadered_fasta/a0951432-cd94-45b5-96d5-b721c037a451.fasta",
             "type": "fasta/final"
         }
     ],
     "e80f3c63-d139-4c14-bd72-7a43897ab40d": [
         {
-            "file": "reheadered-fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta",
+            "file": "reheadered_fasta/e80f3c63-d139-4c14-bd72-7a43897ab40d.fasta",
             "type": "fasta/final"
         }
     ]


### PR DESCRIPTION
**Changes**
In the sars-cov-2 pipelines, the tasks for reheadering/storing/standardising a fasta file occur in separate processes. This means that they require the spin up of dedicated docker containers. These processes run quickly and this way of executing them is inefficient. Actual changes:
* illumina / ont samples: the ncov process takes care of the reheadering (invoking the python script directly) of the output fasta file and publishing of this latter file
* fasta samples: the standardisation (which is actually a file renaming) and publication of reheadered fasta are accomplished by the reheadering process.

**Outcome**
For a batch of 400 samples, this change avoids the creation of 2x400 jobs.

**Testing**
The reheadered fasta is now simply a by product of ncov. If samples are fasta, the reheadering process is retained but it includes the standarisation and publishing.
Note that the expected output files are validated by our unit and validation tests, so nothing has changed on that front. 
```
(venv-psga-pipeline) pierodallepezze@CONGENICA-0256:~/psga-pipeline/minikube$ k exec -it sars-cov-2-pipeline-minikube-6664c55484-b5mwc -- bash 
root@sars-cov-2-pipeline-minikube-6664c55484-b5mwc:/app/psga# nextflow run . --run pipeline_ci_ont --sequencing_technology ont --kit unknown --metadata /data/pipeline_ci_tests/ont/metadata.csv --output_path /data/output/pipeline_ci_ont
N E X T F L O W  ~  version 22.10.0
Launching `./main.nf` [loving_hypatia] DSL2 - revision: 9ec850e2bd
WARN: K8s namespace provided in the nextflow configuration does not match with pod namespace
[c1/3e843d] Submitted process > psga:organise_metadata_sample_files:check_metadata (metadata.csv)
[19/078685] Submitted process > psga:organise_metadata_sample_files:stage_sample_bam (1 - d3e958b5-0c56-48d6-807b-6a89f61408ce.bam)
[07/a41fea] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (1 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fq.gz)
[5c/c5f704] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (2 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[a8/bf8cb1] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (3 - 980f552f-9e50-4d0a-a9fc-dc1398a8bebf.fastq.gz)
[ab/3fba6d] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (4 - d95c7267-c0b0-4b53-b1ba-91fb85cc109e.fastq)
[5f/7e8b9d] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (5 - 9cae232f-6fc6-4a1c-ad06-99ca23b01bfa.fastq)
[55/9b15fe] Submitted process > psga:contamination_removal (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[23/e248b2] Submitted process > psga:contamination_removal (2 - 980f552f-9e50-4d0a-a9fc-dc1398a8bebf.fastq.gz)
[11/3d7b7b] Submitted process > psga:organise_metadata_sample_files:bam_to_fastq (1 - d3e958b5-0c56-48d6-807b-6a89f61408ce.bam)
[c8/e82fda] Submitted process > psga:contamination_removal (3 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fq.gz)
[2f/b64def] Submitted process > psga:contamination_removal (4 - d95c7267-c0b0-4b53-b1ba-91fb85cc109e.fastq)
[73/fb4003] Submitted process > psga:contamination_removal (5 - 9cae232f-6fc6-4a1c-ad06-99ca23b01bfa.fastq)
[90/ce39eb] Submitted process > psga:fastqc (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz)
[17/d15559] Submitted process > psga:contamination_removal (6 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fastq)
[a6/291bde] Submitted process > psga:fastqc (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq.gz)
[db/028146] Submitted process > psga:primer_autodetection (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz)
[72/779d9c] Submitted process > psga:fastqc (3 - d95c7267-c0b0-4b53-b1ba-91fb85cc109e.fastq.gz)
[d4/69cc48] Submitted process > psga:fastqc (4 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fastq.gz)
[33/d7e0a6] Submitted process > psga:primer_autodetection (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq.gz)
[ef/b8832c] Submitted process > psga:ncov2019_artic (1 - [b833399a-4d49-4d00-abdb-39d5086a5a0d_primer.txt, b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz])
[97/665a0a] Submitted process > psga:primer_autodetection (3 - d95c7267-c0b0-4b53-b1ba-91fb85cc109e.fastq.gz)
[fb/f20c50] Submitted process > psga:primer_autodetection (4 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fastq.gz)
[e4/b61c84] Submitted process > psga:fastqc (5 - 9cae232f-6fc6-4a1c-ad06-99ca23b01bfa.fastq.gz)
[a1/ffcc12] Submitted process > psga:ncov2019_artic (2 - [2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb_primer.txt, 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq.gz])
[06/9e92cd] Submitted process > psga:ncov2019_artic (3 - [d95c7267-c0b0-4b53-b1ba-91fb85cc109e_primer.txt, d95c7267-c0b0-4b53-b1ba-91fb85cc109e.fastq.gz])
[6c/1ad12e] Submitted process > psga:ncov2019_artic (4 - [d3e958b5-0c56-48d6-807b-6a89f61408ce_primer.txt, d3e958b5-0c56-48d6-807b-6a89f61408ce.fastq.gz])
[e5/e82d39] Submitted process > psga:primer_autodetection (5 - 9cae232f-6fc6-4a1c-ad06-99ca23b01bfa.fastq.gz)
[25/da4f15] Submitted process > psga:fastqc (6 - 980f552f-9e50-4d0a-a9fc-dc1398a8bebf.fastq.gz)
[21/958916] Submitted process > psga:submit_analysis_run_results:submit_contamination_removal_results
[72/40c42c] Submitted process > psga:ncov2019_artic (5 - [9cae232f-6fc6-4a1c-ad06-99ca23b01bfa_primer.txt, 9cae232f-6fc6-4a1c-ad06-99ca23b01bfa.fastq.gz])
[71/04e4f1] Submitted process > psga:primer_autodetection (6 - 980f552f-9e50-4d0a-a9fc-dc1398a8bebf.fastq.gz)
[53/97986b] Submitted process > psga:pangolin (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[d8/4200d9] Submitted process > psga:submit_analysis_run_results:submit_primer_autodetection_results
[11/d272c1] Submitted process > psga:ncov2019_artic (6 - [980f552f-9e50-4d0a-a9fc-dc1398a8bebf_primer.txt, 980f552f-9e50-4d0a-a9fc-dc1398a8bebf.fastq.gz])
[70/1033e8] Submitted process > psga:pangolin (2 - d95c7267-c0b0-4b53-b1ba-91fb85cc109e.fasta)
[ab/5f054b] Submitted process > psga:pangolin (3 - d3e958b5-0c56-48d6-807b-6a89f61408ce.fasta)
[5b/aff767] Submitted process > psga:pangolin (4 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fasta)
[b5/c1c843] Submitted process > psga:pangolin (5 - 9cae232f-6fc6-4a1c-ad06-99ca23b01bfa.fasta)
[b4/72bc65] Submitted process > psga:pangolin (6 - 980f552f-9e50-4d0a-a9fc-dc1398a8bebf.fasta)
[e4/fc85b8] Submitted process > psga:submit_analysis_run_results:submit_ncov_qc_results
[90/5503da] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[ac/075a9d] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
root@sars-cov-2-pipeline-minikube-6664c55484-b5mwc:/app/psga# cd /app/jenkins && pytest test_validation.py --results-csv /data/output/pipeline_ci_ont/results.csv  --expected-results-csv /app/jenkins/files/sars_cov_2/expected_results/pipeline_ci_ont/results.csv --output-path /data/output/pipeline_ci_ont --pathogen sars_cov_2 --sequencing-technology ont && cd -
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /
plugins: socket-0.3.5
collected 1 item                                                                                                                                                               

test_validation.py .                                                                                                                                                     [100%]

============================================================================== 1 passed in 0.29s ===============================================================================


root@sars-cov-2-pipeline-minikube-6664c55484-b5mwc:/app/psga# nextflow run . --run pipeline_ci_unknown --sequencing_technology unknown --kit none --metadata /data/pipeline_ci_tests/unknown/metadata.csv --output_path /data/output/pipeline_ci_unknown
N E X T F L O W  ~  version 22.10.0

Launching `./main.nf` [ecstatic_hoover] DSL2 - revision: 9ec850e2bd
WARN: K8s namespace provided in the nextflow configuration does not match with pod namespace
[dc/37fb84] Submitted process > psga:organise_metadata_sample_files:check_metadata (metadata.csv)
[14/3783df] Submitted process > psga:organise_metadata_sample_files:stage_sample_fasta (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[b6/5d764c] Submitted process > psga:organise_metadata_sample_files:stage_sample_fasta (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fa)
[76/19b9a2] Submitted process > psga:reheader_fasta (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[8f/3161f9] Submitted process > psga:reheader_fasta (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fa)
[69/4ed32b] Submitted process > psga:pangolin (1 - 19fc4e8f-982c-4679-a37a-0501f3ccb7cc.fasta)
[1f/821508] Submitted process > psga:pangolin (2 - 1a55b645-5cce-400d-b668-e281a95b4c72.fasta)
[7b/e9fa96] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[aa/4d2de6] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
root@sars-cov-2-pipeline-minikube-6664c55484-b5mwc:/app/psga# cd /app/jenkins && pytest test_validation.py --results-csv /data/output/pipeline_ci_unknown/results.csv  --expected-results-csv /app/jenkins/files/sars_cov_2/expected_results/pipeline_ci_unknown/results.csv --output-path /data/output/pipeline_ci_unknown --pathogen sars_cov_2 --sequencing-technology unknown && cd -
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /
plugins: socket-0.3.5
collected 1 item                                                                                                                                                               

test_validation.py .                                                                                                                                                     [100%]

============================================================================== 1 passed in 0.25s ===============================================================================


root@sars-cov-2-pipeline-minikube-6664c55484-b5mwc:/app/psga# nextflow run . --run pipeline_ci_illumina --sequencing_technology illumina --kit unknown --metadata /data/pipeline_ci_tests/illumina/metadata.csv --output_path /data/output/pipeline_ci_illumina
N E X T F L O W  ~  version 22.10.0
Launching `./main.nf` [dreamy_pauling] DSL2 - revision: 9ec850e2bd
WARN: K8s namespace provided in the nextflow configuration does not match with pod namespace
[53/93695f] Submitted process > psga:organise_metadata_sample_files:check_metadata (metadata.csv)
[09/fec316] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (2 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fq, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fq])
[2b/94158d] Submitted process > psga:organise_metadata_sample_files:stage_sample_bam (2 - 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.bam)
[60/5c03f3] Submitted process > psga:organise_metadata_sample_files:stage_sample_bam (1 - 0c0b5622-d63a-42cc-a804-13d71e1a5306.bam)
[74/0a9e1f] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (1 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[ae/72157b] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (3 - [5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb_1.fastq.gz, 5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb_2.fastq.gz])
[2b/60c02c] Submitted process > psga:organise_metadata_sample_files:bam_to_fastq (1 - 0c0b5622-d63a-42cc-a804-13d71e1a5306.bam)
[9a/7c1f9f] Submitted process > psga:contamination_removal (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fq, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fq])
[55/2fc4f1] Submitted process > psga:organise_metadata_sample_files:bam_to_fastq (2 - 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.bam)
[0a/cd160f] Submitted process > psga:contamination_removal (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[81/f9aa9f] Submitted process > psga:contamination_removal (3 - [5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb_1.fastq.gz, 5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb_2.fastq.gz])
[27/c5d17c] Submitted process > psga:contamination_removal (4 - [0c0b5622-d63a-42cc-a804-13d71e1a5306_1.fastq.gz, 0c0b5622-d63a-42cc-a804-13d71e1a5306_2.fastq.gz])
[d7/c0f159] Submitted process > psga:fastqc (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fastq.gz, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fastq.gz])
[64/6bfd8d] Submitted process > psga:contamination_removal (5 - [39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_1.fastq.gz, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_2.fastq.gz])
[f3/d88ed6] Submitted process > psga:fastqc (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[2d/0f133f] Submitted process > psga:fastqc (3 - [5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb_1.fastq.gz, 5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb_2.fastq.gz])
[19/e6854a] Submitted process > psga:primer_autodetection (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fastq.gz, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fastq.gz])
[fd/7fd1b3] Submitted process > psga:primer_autodetection (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[6e/fa1335] Submitted process > psga:fastqc (4 - [0c0b5622-d63a-42cc-a804-13d71e1a5306_1.fastq.gz, 0c0b5622-d63a-42cc-a804-13d71e1a5306_2.fastq.gz])
[b4/163463] Submitted process > psga:primer_autodetection (3 - [5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb_1.fastq.gz, 5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb_2.fastq.gz])
[07/04e3f2] Submitted process > psga:fastqc (5 - [39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_1.fastq.gz, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_2.fastq.gz])
[87/c49360] Submitted process > psga:submit_analysis_run_results:submit_contamination_removal_results
[9e/7dcc2e] Submitted process > psga:ncov2019_artic (1 - [aff01b7c-8a0a-40bf-927a-0548add8ea5a_primer.txt, aff01b7c-8a0a-40bf-927a-0548add8ea5a_1.fastq.gz, aff01b7c-8a0a-40bf-927a-0548add8ea5a_2.fastq.gz])
[d1/fd42a9] Submitted process > psga:ncov2019_artic (2 - [9729bce7-f0a9-4617-b6e0-6145307741d1_primer.txt, 9729bce7-f0a9-4617-b6e0-6145307741d1_1.fastq.gz, 9729bce7-f0a9-4617-b6e0-6145307741d1_2.fastq.gz])
[a5/9a6c41] Submitted process > psga:primer_autodetection (4 - [0c0b5622-d63a-42cc-a804-13d71e1a5306_1.fastq.gz, 0c0b5622-d63a-42cc-a804-13d71e1a5306_2.fastq.gz])
[37/33624f] Submitted process > psga:ncov2019_artic (3 - [5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb_primer.txt, 5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb_1.fastq.gz, 5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb_2.fastq.gz])
[98/6baadb] Submitted process > psga:primer_autodetection (5 - [39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_1.fastq.gz, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_2.fastq.gz])
[8a/397510] Submitted process > psga:ncov2019_artic (4 - [0c0b5622-d63a-42cc-a804-13d71e1a5306_primer.txt, 0c0b5622-d63a-42cc-a804-13d71e1a5306_1.fastq.gz, 0c0b5622-d63a-42cc-a804-13d71e1a5306_2.fastq.gz])
[25/c47510] Submitted process > psga:submit_analysis_run_results:submit_primer_autodetection_results
[ba/2d6ea0] Submitted process > psga:ncov2019_artic (5 - [39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_primer.txt, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_1.fastq.gz, 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b_2.fastq.gz])
[f3/eaa598] Submitted process > psga:pangolin (1 - aff01b7c-8a0a-40bf-927a-0548add8ea5a.fasta)
[12/769a10] Submitted process > psga:pangolin (2 - 9729bce7-f0a9-4617-b6e0-6145307741d1.fasta)
[84/3a96fc] Submitted process > psga:pangolin (3 - 5695c67c-b7ac-4fc2-96f0-f1ffc68c03fb.fasta)
[a2/309a74] Submitted process > psga:pangolin (4 - 0c0b5622-d63a-42cc-a804-13d71e1a5306.fasta)
[c8/efe840] Submitted process > psga:pangolin (5 - 39330daf-8dc6-4faa-a2d0-a2c1c909ab3b.fasta)
[a1/e18fea] Submitted process > psga:submit_analysis_run_results:submit_ncov_qc_results
[c6/8fda9b] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[34/5f7b37] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
root@sars-cov-2-pipeline-minikube-6664c55484-b5mwc:/app/psga# cd /app/jenkins && pytest test_validation.py --results-csv /data/output/pipeline_ci_illumina/results.csv  --expected-results-csv /app/jenkins/files/sars_cov_2/expected_results/pipeline_ci_illumina/results.csv --output-path /data/output/pipeline_ci_illumina --pathogen sars_cov_2 --sequencing-technology illumina && cd -
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /
plugins: socket-0.3.5
collected 1 item                                                                                                                                                               

test_validation.py .                                                                                                                                                     [100%]

============================================================================== 1 passed in 0.24s ===============================================================================
```