### PR TITLE
PSG-2711: pin poetry versions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -460,11 +460,11 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "urllib3"
-version = "1.26.12"
+version = "1.26.14"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
@@ -491,7 +491,7 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "95441d871303d8c958c6d2c494284ea4399ddc7f01cc6a12a2a28ce886277196"
+content-hash = "bd7d88dc78ecd14e78eddff68b6c22daf46977430c5725aec4cf8964380f6376"
 
 [metadata.files]
 attrs = [
@@ -830,8 +830,8 @@ tomli = [
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.12-py2.py3-none-any.whl", hash = "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"},
-    {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
+    {file = "urllib3-1.26.14-py2.py3-none-any.whl", hash = "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"},
+    {file = "urllib3-1.26.14.tar.gz", hash = "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72"},
 ]
 virtualenv = [
     {file = "virtualenv-20.16.5-py3-none-any.whl", hash = "sha256:d07dfc5df5e4e0dbc92862350ad87a36ed505b978f6c39609dc489eadd5b0d27"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,24 +7,24 @@ license = "GNU AFFERO GENERAL PUBLIC LICENSE V3"
 
 [tool.poetry.dependencies]
 awscli = "1.22.50"
-click = "~7.1"
-biopython = "^1.78"
-natsort = "^7.1.0"
+click = "7.1.2"
+biopython = "1.79"
+natsort = "7.1.1"
 pre-commit = "2.17.0"
 pytest = "7.1.3"
-pytest-socket = "^0.3.5"
+pytest-socket = "0.3.5"
 python = "^3.10"
 psutil = "5.9.0"
-pandas = "^1.4.2"
-marshmallow = "^3.15.0"
-structlog = "^21.5.0"
-urllib3 = "1.26.12"
-GitPython = "^3.1.29"
+pandas = "1.5.0"
+marshmallow = "3.18.0"
+structlog = "21.5.0"
+urllib3 = "1.26.14"
+GitPython = "3.1.29"
 pyahocorasick = "1.4.4"
 
 [tool.poetry.dev-dependencies]
-pytest = "~7.1"
+pytest = "7.1.3"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
+requires = ["poetry-core==1.0.8"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Pins the versions completely, based on what we have in the psga-pipeline docker image.

(please, discard CircleCi Pipeline requirement)