### PR TITLE
PSG-2603: update ncov2019-artic-nf dependencies

### DIFF
--- a/docker/Dockerfile.ncov2019-artic-nf-illumina
+++ b/docker/Dockerfile.ncov2019-artic-nf-illumina
@@ -2,9 +2,7 @@ FROM condaforge/mambaforge:4.14.0-0 AS condabuild
 
 ARG pathogen
 COPY docker/${pathogen}/ncov2019-artic-nf/environments/illumina/environment.yml /environment.yml
-# Also reinstall packages to pinned versions, as the conda-selected downgraded ones fail to run
 RUN mamba env create -f /environment.yml -n custom_env \
-  && mamba install -y -c conda-forge -c bioconda cutadapt==3.1 dnaio==0.4.4 -n custom_env \
   && conda clean --all -y
 
 
@@ -27,6 +25,3 @@ COPY psga/${pathogen}/ncov-illumina.config psga/${pathogen}/ncov-common.config /
 COPY data/${pathogen}/ncov2019-artic-nf/* /
 COPY data/${pathogen}/primer_schemes /primer_schemes
 COPY scripts/common /app/scripts/common
-
-# install awscli here because the conda version requires a much more updated Python version
-RUN pip install awscli==1.20.50

--- a/docker/Dockerfile.ncov2019-artic-nf-nanopore
+++ b/docker/Dockerfile.ncov2019-artic-nf-nanopore
@@ -2,9 +2,7 @@ FROM condaforge/mambaforge:4.14.0-0 AS condabuild
 
 ARG pathogen
 COPY docker/${pathogen}/ncov2019-artic-nf/environments/nanopore/environment.yml /environment.yml
-# Also reinstall these two packages to their latest version, as the conda-selected downgraded ones fail to run
 RUN mamba env create -f /environment.yml -n custom_env \
-  && mamba install -y -c conda-forge -c bioconda cutadapt==3.1 dnaio==0.4.4 -n custom_env \
   && conda clean --all -y
 
 
@@ -34,5 +32,3 @@ COPY psga/${pathogen}/ncov-nanopore.config psga/${pathogen}/ncov-common.config /
 COPY data/${pathogen}/ncov2019-artic-nf/* /
 COPY data/${pathogen}/primer_schemes /primer_schemes
 COPY scripts/common /app/scripts/common
-
-RUN pip install awscli==1.20.50


### PR DESCRIPTION
**Changes**
* update critical tools: `nextflow`, `bwa` and `python`. See: https://github.com/Congenica/ncov2019-artic-nf/pull/10 
* it looks like that it is no longer required to pin: `cutadapt` and `dnaio` after updating the tools above.
* `awscli` is now installed via conda

**Testing 1**
Docker images ship updated nextflow:
```
$ docker run -it --rm 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod/ncov2019-artic-nf-illumina:dev_latest bash 
root@e79337c1b64e:/# nextflow -version
      N E X T F L O W
      version 22.10.0 build 5826
      created 13-10-2022 05:44 UTC 
      cite doi:10.1038/nbt.3820
      http://nextflow.io
$ docker run -it --rm 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod/ncov2019-artic-nf-nanopore:dev_latest bash 
root@20d528b5ab42:/# nextflow -version 
      N E X T F L O W
      version 22.10.0 build 5826
      created 13-10-2022 05:44 UTC 
      cite doi:10.1038/nbt.3820
      http://nextflow.io
```

**Testing 2**
Our integration tests pass fine with no change to the expected results:
```
root@sars-cov-2-pipeline-minikube-6664c55484-hjbtl:/app/psga# nextflow run . --run pipeline_ci_illumina --sequencing_technology illumina --kit unknown --metadata /data/pipeline_ci_tests/illumina/metadata.csv --output_path /data/output/pipeline_ci_illumina

[..output as usual..]

root@sars-cov-2-pipeline-minikube-6664c55484-hjbtl:/app/psga# cd /app/integration_tests && pytest test_validation.py --results-csv /data/output/pipeline_ci_illumina/results.csv  --expected-results-csv /app/integration_tests/expected_data/sars_cov_2/illumina_unknown/results.csv --output-path /data/output/pipeline_ci_illumina --pathogen sars_cov_2 --sequencing-technology illumina && cd -
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /
plugins: socket-0.3.5
collected 1 item                                                                                                                                                               

test_validation.py .                                                                                                                                                     [100%]

============================================================================== 1 passed in 0.27s ===============================================================================

root@sars-cov-2-pipeline-minikube-6664c55484-hjbtl:/app/psga# nextflow run . --run pipeline_ci_illumina --sequencing_technology illumina --kit unknown --metadata /data/pipeline_ci_tests/illumina/metadata.csv --output_path /data/output/pipeline_ci_illumina

[..output as usual..]

root@sars-cov-2-pipeline-minikube-6664c55484-hjbtl:/app/psga# cd /app/integration_tests && pytest test_validation.py --results-csv /data/output/pipeline_ci_illumina/results.csv  --expected-results-csv /app/integration_tests/expected_data/sars_cov_2/illumina_unknown/results.csv --output-path /data/output/pipeline_ci_illumina --pathogen sars_cov_2 --sequencing-technology illumina && cd -
============================================================================= test session starts ==============================================================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0
rootdir: /
plugins: socket-0.3.5
collected 1 item                                                                                                                                                               

test_validation.py .                                                                                                                                                     [100%]

============================================================================== 1 passed in 0.29s ===============================================================================
```

**Testing 3**
I've executed 3 of those samples which failed 1 year ago and now they complete fine. Those samples used to fail for the same reason (see ticket). 
```
# List of odd samples:
root@sars-cov-2-pipeline-minikube-6664c55484-hjbtl:/data/odd_ont_samples# ls -l 
total 2136360
-rw-rw-r-- 1 1001 1001 1349629651 Feb 21 10:37 ERR5473333-barcode091.fastq
-rw-rw-r-- 1 1001 1001   43510771 Feb 21 10:37 ERR8193988-barcode201.fastq
-rw-rw-r-- 1 1001 1001   30132271 Feb 21 10:37 ERR8195100-barcode214.fastq
-rw-rw-r-- 1 1001 1001   66765776 Feb 21 10:37 ERR8195120-barcode220.fastq
-rw-rw-r-- 1 1001 1001   58793542 Feb 21 10:37 ERR8195499-barcode228.fastq
-rw-rw-r-- 1 1001 1001   46923785 Feb 21 10:37 ERR8195503-barcode229.fastq
-rw-rw-r-- 1 1001 1001   69250240 Feb 21 10:37 ERR8195830-barcode238.fastq
-rw-rw-r-- 1 1001 1001   69632495 Feb 21 10:37 ERR8196365-barcode255.fastq
-rw-rw-r-- 1 1001 1001   82077891 Feb 21 10:37 ERR8198068-barcode275.fastq
-rw-rw-r-- 1 1001 1001   95731580 Feb 21 10:37 ERR8198074-barcode278.fastq
-rw-rw-r-- 1 1001 1001  103364507 Feb 21 10:37 ERR8198323-barcode281.fastq
-rw-rw-r-- 1 1001 1001  111191187 Feb 21 10:37 ERR8198966-barcode291.fastq
-rw-rw-r-- 1 1001 1001   60561254 Feb 21 10:37 ERR8199302-barcode295.fastq

root@sars-cov-2-pipeline-minikube-6664c55484-hjbtl:/app/psga# nextflow run . --run odd_ont_samples --sequencing_technology ont --kit ARTIC_V4 --metadata /data/odd_ont_samples/metadata.csv --output_path /data/output/odd_ont_samples
N E X T F L O W  ~  version 22.10.0
Launching `./main.nf` [goofy_snyder] DSL2 - revision: 9ec850e2bd
WARN: K8s namespace provided in the nextflow configuration does not match with pod namespace
[bc/8722e4] Submitted process > psga:organise_metadata_sample_files:check_metadata (metadata.csv)
[0f/7da813] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (2 - ERR8193988-barcode201.fastq)
[c6/03ffd3] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (1 - ERR8195120-barcode220.fastq)
[39/333fd3] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (3 - ERR8195100-barcode214.fastq)
[34/3d0330] Submitted process > psga:contamination_removal (1 - ERR8193988-barcode201.fastq)
[ff/17ba09] Submitted process > psga:contamination_removal (2 - ERR8195120-barcode220.fastq)
[98/3550c1] Submitted process > psga:contamination_removal (3 - ERR8195100-barcode214.fastq)
[f6/aaded8] Submitted process > psga:fastqc (1 - ERR8193988-barcode201.fastq.gz)
[91/8ef6e5] Submitted process > psga:fastqc (2 - ERR8195100-barcode214.fastq.gz)
[09/b602c9] Submitted process > psga:fastqc (3 - ERR8195120-barcode220.fastq.gz)
[8a/fd5d31] Submitted process > psga:submit_analysis_run_results:submit_contamination_removal_results
[dc/0850c3] Submitted process > psga:primer_autodetection (1 - ERR8193988-barcode201.fastq.gz)
[8c/23ab19] Submitted process > psga:primer_autodetection (2 - ERR8195100-barcode214.fastq.gz)
[54/fac9cf] Submitted process > psga:primer_autodetection (3 - ERR8195120-barcode220.fastq.gz)
[3a/5151c8] Submitted process > psga:ncov2019_artic (1 - [ERR8193988-barcode201_primer.txt, ERR8193988-barcode201.fastq.gz])
[06/820051] Submitted process > psga:ncov2019_artic (2 - [ERR8195100-barcode214_primer.txt, ERR8195100-barcode214.fastq.gz])
[10/a252c7] Submitted process > psga:submit_analysis_run_results:submit_primer_autodetection_results
[06/3e7964] Submitted process > psga:ncov2019_artic (3 - [ERR8195120-barcode220_primer.txt, ERR8195120-barcode220.fastq.gz])
[01/ecfd43] Submitted process > psga:pangolin (1 - ERR8195100-barcode214.fasta)
[7d/1d2336] Submitted process > psga:pangolin (2 - ERR8193988-barcode201.fasta)
[9b/e57a23] Submitted process > psga:pangolin (3 - ERR8195120-barcode220.fasta)
[8d/c12584] Submitted process > psga:submit_analysis_run_results:submit_ncov_qc_results
[ec/4cfcfc] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[b1/cae491] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
root@sars-cov-2-pipeline-minikube-6664c55484-hjbtl:/app/psga# cat /data/output/odd_ont_samples/results.csv 
SAMPLE_ID,STATUS,CONTAMINATED_READS,PRIMER_DETECTED,PRIMER_NUMREADS,PRIMER_UNIQUE_NUMREADS,PRIMER_AMBIGUOUS_NUMREADS,PRIMER_COVERAGE,PRIMER_INPUT,NCOV_PCT_N_BASES,NCOV_PCT_COVERED_BASES,NCOV_LONGEST_NO_N_RUN,NCOV_NUM_ALIGNED_READS,NCOV_QC_PASS,PANGOLIN_LINEAGE,PANGOLIN_CONFLICT,PANGOLIN_AMBIGUITY_SCORE,PANGOLIN_SCORPIO_CALL,PANGOLIN_SCORPIO_SUPPORT,PANGOLIN_SCORPIO_CONFLICT,PANGOLIN_SCORPIO_NOTES,PANGOLIN_PANGO_DESIGNATION_VERSION,PANGOLIN_VERSION,PANGOLIN_SCORPIO_VERSION,PANGOLIN_CONSTELLATION_VERSION,PANGOLIN_IS_DESIGNATED,PANGOLIN_QC_STATUS,PANGOLIN_QC_NOTES,PANGOLIN_NOTE
ERR8193988-barcode201,Completed,0,none,0,0,0,0,ARTIC_V4,18.42,81.2,3191,23577,True,BA.1.17,0.0,,Probable Omicron (Unassigned),0.42,0.03,scorpio call: Alt alleles 14; Ref alleles 1; Amb alleles 18; Oth alleles 0,PUSHER-v1.18,4.2,0.3.17,v0.1.10,False,pass,Ambiguous_content:0.2,Usher placements: BA.1.17(1/1); scorpio found insufficient support to assign a specific lineage
ERR8195100-barcode214,Completed,0,none,0,0,0,0,ARTIC_V4,16.81,83.34,3921,22505,True,BA.1,0.0,,Probable Omicron (Unassigned),0.36,0.03,scorpio call: Alt alleles 12; Ref alleles 1; Amb alleles 19; Oth alleles 1,PUSHER-v1.18,4.2,0.3.17,v0.1.10,False,pass,Ambiguous_content:0.18,Usher placements: BA.1(1/1); scorpio found insufficient support to assign a specific lineage
ERR8195120-barcode220,Completed,2,none,0,0,0,0,ARTIC_V4,18.13,81.75,3409,26585,True,BA.1,0.0,,Probable Omicron (Unassigned),0.42,0.03,scorpio call: Alt alleles 14; Ref alleles 1; Amb alleles 18; Oth alleles 0,PUSHER-v1.18,4.2,0.3.17,v0.1.10,False,pass,Ambiguous_content:0.19,Usher placements: BA.1(1/1); scorpio found insufficient support to assign a specific lineage
```

**Testing 4:**
Executed CQ2a_mini test set using the old and new ncov docker images. There is no change.