### PR TITLE
PSG-3287 fix build

### DIFF
--- a/docker/Dockerfile.psga-pipeline
+++ b/docker/Dockerfile.psga-pipeline
@@ -44,6 +44,10 @@ RUN nextflow plugin install nf-amazon@1.11.0 \
   && pip install setuptools==63.1.0 \
   && pip install --progress-bar=off --no-cache-dir --upgrade pip==${PIP_VERSION} \
   && pip install --progress-bar=off --no-cache-dir poetry==${POETRY_VERSION} \
+  # the following uninstall & install commands are a fix for urllib3 being installed by something else
+  # in a version that breaks poetry installation, e.g. see https://github.com/psf/requests/issues/6437
+  && pip uninstall -y urllib3 \
+  && pip install urllib3==1.26.14 \
   && poetry config virtualenvs.create false \
   && poetry install --no-interaction --no-ansi --no-dev
 

--- a/docker/Dockerfile.psga-pipeline
+++ b/docker/Dockerfile.psga-pipeline
@@ -45,7 +45,7 @@ RUN nextflow plugin install nf-amazon@1.11.0 \
   && pip install --progress-bar=off --no-cache-dir --upgrade pip==${PIP_VERSION} \
   && pip install --progress-bar=off --no-cache-dir poetry==${POETRY_VERSION} \
   # the following uninstall & install commands are a fix for urllib3 being installed by something else
-  # in a version that breaks poetry installation, e.g. see https://github.com/psf/requests/issues/6437
+  # in a version that breaks poetry installation, e.g. see https://github.com/python-poetry/poetry/issues/7878
   && pip uninstall -y urllib3 \
   && pip install urllib3==1.26.14 \
   && poetry config virtualenvs.create false \


### PR DESCRIPTION
When poetry tries to install packages, urllib3 is already installed at a latest version which is incompatible with the chosen poetry version and the poetry install fails. This replaces the urllib3 package with a version compatible with the installer.