### PR TITLE
PSG-3268: Remove SAMPLE_ID from all of the output schemas

### DIFF
--- a/psga/config/psga-schema-s-aureus.yaml
+++ b/psga/config/psga-schema-s-aureus.yaml
@@ -49,16 +49,6 @@ input_fields:
 
 
 output_fields:
-  - field_name: SAMPLE_ID
-    field_type: string
-    required: true
-    validation_rules:
-      - rule_type: min_max
-        min: 36
-        max: 36
-      - rule_type: regex
-        expression: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-
   - field_name: STATUS
     field_type: string
     required: false

--- a/psga/config/psga-schema-sars-cov-2.yaml
+++ b/psga/config/psga-schema-sars-cov-2.yaml
@@ -392,16 +392,6 @@ input_fields:
 #- {}
 
 output_fields:
-  - field_name: SAMPLE_ID
-    field_type: string
-    required: true
-    validation_rules:
-      - rule_type: min_max
-        min: 36
-        max: 36
-      - rule_type: regex
-        expression: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-
   - field_name: STATUS
     field_type: string
     required: true

--- a/psga/config/psga-schema-synthetic.yaml
+++ b/psga/config/psga-schema-synthetic.yaml
@@ -86,16 +86,6 @@ input_fields:
 #- {}
 
 output_fields:
-  - field_name: SAMPLE_ID
-    field_type: string
-    required: true
-    validation_rules:
-      - rule_type: min_max
-        min: 36
-        max: 36
-      - rule_type: regex
-        expression: "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-
   - field_name: STATUS
     field_type: string
     required: true


### PR DESCRIPTION
The output schema is used by the front end to provide a list of filter options. The SAMPLE_ID is not making it into the output metadata. So when the user tries to use this field to filter samples it is not working.

The sample id is in the input metadata so this can be used to successfully filter samples to a single one.