### PR TITLE
PSG-3615: add procps dependency which is required in order to generate nextflow reports

### DIFF
--- a/docker/sars_cov_2/README
+++ b/docker/sars_cov_2/README
@@ -1,0 +1,3 @@
+The dependency `procps-ng` is needed in order to execute `ps`, which is required
+for generating reports.
+`ps` is already available in the two ncov docker images

--- a/docker/sars_cov_2/fastqc.yml
+++ b/docker/sars_cov_2/fastqc.yml
@@ -4,4 +4,5 @@ channels:
   - conda-forge # required for awscli
 dependencies:
   - awscli=1.25.92
+  - procps-ng=4.0.3   # required for ps
   - fastqc=0.11.9

--- a/docker/sars_cov_2/htstools.yml
+++ b/docker/sars_cov_2/htstools.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge # required for awscli
 dependencies:
   - awscli=1.25.92
+  - procps-ng=4.0.3   # required for ps
   - htslib=1.16
   - samtools=1.16.1
   - bcftools=1.16

--- a/docker/sars_cov_2/pangolin.yml
+++ b/docker/sars_cov_2/pangolin.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge # required for awscli
 dependencies:
   - awscli=1.25.92
+  - procps-ng=4.0.3   # required for ps
   - pangolin=4.2
   - pangolin-data=1.19
   - scorpio=0.3.17

--- a/docker/sars_cov_2/primer-autodetection.yml
+++ b/docker/sars_cov_2/primer-autodetection.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge # required for awscli, click, pandas
 dependencies:
   - awscli=1.25.92
+  - procps-ng=4.0.3   # required for ps
   - pip:
     - biopython==1.80
     - click==7.1.2

--- a/docker/sars_cov_2/psga.yml
+++ b/docker/sars_cov_2/psga.yml
@@ -7,4 +7,5 @@ dependencies:
   - nextflow=22.10.0
   - make=4.3
   - gcc=12.1.0
+  - procps-ng=4.0.3   # required for ps
   - python=3.10.6

--- a/docker/sars_cov_2/read-it-and-keep.yml
+++ b/docker/sars_cov_2/read-it-and-keep.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge # required for awscli, click
 dependencies:
   - awscli=1.25.92
+  - procps-ng=4.0.3   # required for ps
   - read-it-and-keep=0.3.0
   - pip:
     - click==7.1.2

--- a/docker/synthetic/psga.yml
+++ b/docker/synthetic/psga.yml
@@ -7,4 +7,5 @@ dependencies:
   - nextflow=22.10.0
   - make=4.3
   - gcc=12.1.0
+  - procps-ng=4.0.3   # required for ps
   - python=3.10.6


### PR DESCRIPTION
Before this PR, the command `nextflow run . --run ont --sequencing_technology ont --kit unknown --metadata /data/synthetic-ont/metadata.csv --tput_path /data/output/pipeline_synthetic_ont -with-report report.html -with-timeline timeline.html` failed with error:
```
Command error:
  Command 'ps' required by nextflow to collect task metrics cannot be found
```


Tested using ont samples. The reports were generated and attached to the ticket.
```
root@sars-cov-2-pipeline-minikube-d85788548-wrbbx:/app/psga# nextflow run . --run ont --sequencing_technology ont --kit unknown --metadata /data/synthetic-ont/metadata.csv --tput_path /data/output/pipeline_synthetic_ont -with-report report.html -with-timeline timeline.html
N E X T F L O W  ~  version 22.10.0
Launching `./main.nf` [special_cori] DSL2 - revision: 9ec850e2bd
WARN: K8s namespace provided in the nextflow configuration does not match with pod namespace
[e5/c1c865] Submitted process > psga:organise_metadata_sample_files:check_metadata (metadata.csv)
[21/1fede4] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (2 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[08/6b7bac] Submitted process > psga:organise_metadata_sample_files:stage_sample_fastq (1 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fq.gz)
[db/8932c2] Submitted process > psga:contamination_removal (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq)
[6a/f80cbc] Submitted process > psga:contamination_removal (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fq.gz)
[a9/8c98b3] Submitted process > psga:fastqc (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz)
[3d/5e5ab3] Submitted process > psga:fastqc (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq.gz)
[6c/73b927] Submitted process > psga:submit_analysis_run_results:submit_contamination_removal_results
[fe/041220] Submitted process > psga:primer_autodetection (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz)
[80/2b2550] Submitted process > psga:primer_autodetection (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq.gz)
[25/b01e25] Submitted process > psga:ncov2019_artic (1 - [b833399a-4d49-4d00-abdb-39d5086a5a0d_primer.txt, b833399a-4d49-4d00-abdb-39d5086a5a0d.fastq.gz])
[eb/75763c] Submitted process > psga:submit_analysis_run_results:submit_primer_autodetection_results
[b2/15c98f] Submitted process > psga:ncov2019_artic (2 - [2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb_primer.txt, 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fastq.gz])
[f8/1b543a] Submitted process > psga:pangolin (1 - b833399a-4d49-4d00-abdb-39d5086a5a0d.fasta)
[4b/35fbb1] Submitted process > psga:pangolin (2 - 2cf78ed4-edae-4943-ab04-5d7a1e4cbdcb.fasta)
[25/bf42e4] Submitted process > psga:submit_analysis_run_results:submit_ncov_qc_results
[5e/116df5] Submitted process > psga:submit_analysis_run_results:submit_pangolin_results
[c7/e3527e] Submitted process > psga:submit_analysis_run_results:submit_pipeline_results_files
```

Note that the required tools were already present in the 2 ncov docker images: 
```
pierodallepezze@CONGENICA-0256:~/psga-pipeline$ docker run -it 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod/ncov2019-artic-nf-illumina:dev_latest bash  
root@f5e678b51b6c:/# which ps 
/bin/ps
root@f5e678b51b6c:/# which sed 
/bin/sed
root@f5e678b51b6c:/# which awk
/usr/bin/awk
root@f5e678b51b6c:/# which date
/opt/conda/envs/custom_env/bin/date
root@f5e678b51b6c:/# which grep
/bin/grep
root@f5e678b51b6c:/# which tail
/opt/conda/envs/custom_env/bin/tail
root@f5e678b51b6c:/# which tee
/opt/conda/envs/custom_env/bin/tee


pierodallepezze@CONGENICA-0256:~/psga-pipeline$ docker run -it 566277102435.dkr.ecr.eu-west-2.amazonaws.com/congenica/psga-nonprod/ncov2019-artic-nf-nanopore:dev_latest bash  
root@3fa5af4f10f5:/# which ps
/bin/ps
root@3fa5af4f10f5:/# which sed 
/bin/sed
root@3fa5af4f10f5:/# which awk
/usr/bin/awk
root@3fa5af4f10f5:/# which date
/opt/conda/envs/custom_env/bin/date
root@3fa5af4f10f5:/# which grep 
/bin/grep
root@3fa5af4f10f5:/# which tail 
/opt/conda/envs/custom_env/bin/tail
root@3fa5af4f10f5:/# which tee
/opt/conda/envs/custom_env/bin/tee
```