### PR TITLE
PSG-3579: Add Allure to unit tests for test traceability

### DIFF
--- a/.github/workflows/check_and_test.yaml
+++ b/.github/workflows/check_and_test.yaml
@@ -44,7 +44,7 @@ jobs:
           ARTIFACT_S3_PATH_PARTIAL=s3://psga-artefacts/allure-results/psga-pipeline
           ARTIFACT_COUNT=$(aws s3 ls $ARTIFACT_S3_PATH_PARTIAL/${{ github.sha }} | wc -l)
           ARTIFACT_NAME=${{ github.sha }}_$ARTIFACT_COUNT.tar.gz
-          ARTIFACT_PATH=${{ env.ALLURE_DIR }}/$ARTIFACT_NAME
+          ARTIFACT_PATH=${{ github.workspace }}/$ARTIFACT_NAME
           tar -czf $ARTIFACT_PATH -C ${{ env.ALLURE_DIR }} .
           echo "ALLURE_RESULTS_POD=$ARTIFACT_PATH" >> $GITHUB_ENV
           echo "ALLURE_RESULTS_S3=$ARTIFACT_S3_PATH_PARTIAL/$ARTIFACT_NAME" >> $GITHUB_ENV

--- a/.github/workflows/check_and_test.yaml
+++ b/.github/workflows/check_and_test.yaml
@@ -5,20 +5,58 @@ jobs:
   check_and_test:
     name: Install dependencies and run tests
     runs-on: ubuntu-22.04
+    env:
+      ALLURE_DIR: ${{ github.workspace }}/allure-results
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
+
       - name: Install python
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+
       - name: Install Poetry
         run: curl -sSL https://install.python-poetry.org | python3 -
+
       - name: Pre-commit checks
         run: |
           pip install pre-commit==2.17.0
           pre-commit run --all-files
+
       - name: Install dependencies and run tests
         run: |
           poetry install
-          poetry run pytest tests/
+          poetry run pytest tests/ --alluredir=${{ env.ALLURE_DIR }}
+
+      # Before copying Allure Results to S3, the number of existing results with the same Git hash are identified. This
+      # number is appended as a suffix to the name of the artifact before copying to S3 to avoid overwriting any
+      # existing results that were captured on this Git hash.
+
+      # For example, when a set of tests are kicked off from a branch where the head of the branch has Git hash
+      # e1e3a8195fecdd78cf0a78c648453314ca872b81:
+
+      #   - The first set of Allure Results will be named e1e3a8195fecdd78cf0a78c648453314ca872b81_0.tar.gz
+      #   - The second set of Allure Results will be named e1e3a8195fecdd78cf0a78c648453314ca872b81_1.tar.gz
+      #   - etc
+      - name: Compress Allure Results
+        run: |
+          ARTIFACT_S3_PATH_PARTIAL=s3://psga-artefacts/allure-results/psga-pipeline
+          ARTIFACT_COUNT=$(aws s3 ls $ARTIFACT_S3_PATH_PARTIAL/${{ github.sha }} | wc -l)
+          ARTIFACT_NAME=${{ github.sha }}_$ARTIFACT_COUNT.tar.gz
+          ARTIFACT_PATH=${{ env.ALLURE_DIR }}/$ARTIFACT_NAME
+          tar -czf $ARTIFACT_PATH -C ${{ env.ALLURE_DIR }} .
+          echo "ALLURE_RESULTS_POD=$ARTIFACT_PATH" >> $GITHUB_ENV
+          echo "ALLURE_RESULTS_S3=$ARTIFACT_S3_PATH_PARTIAL/$ARTIFACT_NAME" >> $GITHUB_ENV
+
+      - name: Upload Allure Results to S3
+        id: upload-to-s3
+        run: aws s3 cp $ALLURE_RESULTS_POD $ALLURE_RESULTS_S3
+
+  test_traceability:
+    needs: check_and_test
+    uses: ./.github/workflows/test_traceability.yml
+    secrets: inherit
+    with:
+      docker_tag: dev_latest
+      trace_to_jira: false

--- a/.github/workflows/check_and_test.yaml
+++ b/.github/workflows/check_and_test.yaml
@@ -29,6 +29,14 @@ jobs:
           poetry install
           poetry run pytest tests/ --alluredir=${{ env.ALLURE_DIR }}
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+          mask-aws-account-id: false
+
       # Before copying Allure Results to S3, the number of existing results with the same Git hash are identified. This
       # number is appended as a suffix to the name of the artifact before copying to S3 to avoid overwriting any
       # existing results that were captured on this Git hash.

--- a/.github/workflows/check_and_test.yaml
+++ b/.github/workflows/check_and_test.yaml
@@ -30,12 +30,12 @@ jobs:
           poetry run pytest tests/ --alluredir=${{ env.ALLURE_DIR }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
-          mask-aws-account-id: false
+          mask-aws-account-id: true
 
       # Before copying Allure Results to S3, the number of existing results with the same Git hash are identified. This
       # number is appended as a suffix to the name of the artifact before copying to S3 to avoid overwriting any
@@ -60,11 +60,3 @@ jobs:
       - name: Upload Allure Results to S3
         id: upload-to-s3
         run: aws s3 cp $ALLURE_RESULTS_POD $ALLURE_RESULTS_S3
-
-  test_traceability:
-    needs: check_and_test
-    uses: ./.github/workflows/test_traceability.yml
-    secrets: inherit
-    with:
-      docker_tag: dev_latest
-      trace_to_jira: false

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -62,3 +62,11 @@ jobs:
   check_and_test:
     name: Install dependencies and run tests
     uses: ./.github/workflows/check_and_test.yaml
+    secrets: inherit
+  test_traceability:
+    needs: check_and_test
+    uses: ./.github/workflows/test_traceability.yml
+    secrets: inherit
+    with:
+      docker_tag: dev_latest
+      trace_to_jira: false

--- a/.github/workflows/release_branch.yml
+++ b/.github/workflows/release_branch.yml
@@ -89,3 +89,10 @@ jobs:
 
       - name: Push the release image to prod
         run: docker push $PROD_RELEASE_NAME
+
+  test_traceability:
+    uses: ./.github/workflows/test_traceability.yml
+    secrets: inherit
+    with:
+      docker_tag: dev_latest
+      trace_to_jira: true

--- a/.github/workflows/test_traceability.yml
+++ b/.github/workflows/test_traceability.yml
@@ -1,0 +1,63 @@
+name: Test traceability
+on:
+  workflow_call:
+    inputs:
+      docker_tag:
+        description: 'The Docker tag of the rt-test-traceability image to use'
+        required: true
+        type: string
+      trace_to_jira:
+        description: 'Bool to control if tests should be traced back to Jira or not'
+        required: true
+        type: boolean
+
+jobs:
+  test-traceability-job:
+    name: Run test-traceability
+    runs-on: psga-prod-build
+    env:
+      CONGENICA_AWS_ACCOUNT_DEV: 144563655722.dkr.ecr.eu-west-1.amazonaws.com
+      REPO_NAME: psga-pipeline
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Pull test-traceability image from the Congenica dev ECR
+        id: pull-test-traceability-image
+        run: |
+          aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin "${{ env.CONGENICA_AWS_ACCOUNT_DEV }}"
+          FULL_IMAGE_PATH=${{ env.CONGENICA_AWS_ACCOUNT_DEV }}/congenica/dev/rt-test-traceability:${{ inputs.docker_tag }}
+          echo "TEST_TRACEABILITY_IMAGE=$FULL_IMAGE_PATH" >> $GITHUB_OUTPUT
+          docker pull $FULL_IMAGE_PATH
+
+      # Passes the most recent set of Allure Results from the current Git hash to the test traceability code. There
+      # could be a race condition where two builds produce a set of Allure Results from the same Git hash at roughly the
+      # same time, leading to the wrong set of Allure Results being used. However, the chances of this are minimal as
+      # two builds executing against a single branch on the same Git hash is highly unlikely.
+      - name: Run test traceability
+        run: |
+          BUCKET_URL_ROOT=s3://psga-artefacts/allure-results/${{ env.REPO_NAME }}
+          BUCKET_URL_PARTIAL=$BUCKET_URL_ROOT/${{ github.sha }}
+          ALLURE_ARTIFACT_NAME=$(aws s3 ls $BUCKET_URL_PARTIAL | awk '{print $4}' | tail -n1)
+          BUCKET_URL_FULL=$BUCKET_URL_ROOT/$ALLURE_ARTIFACT_NAME
+          docker run --env AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}" \
+                     --env AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
+                     --env TT_ALLURE_RESULTS_S3_URL="$BUCKET_URL_FULL" \
+                     --env TT_JIRA_COMPONENT="Analysis" \
+                     --env TT_JIRA_PROJECT_KEY="PSG" \
+                     --env TT_JIRA_TEST_REPOSITORY_PATH="${{ env.REPO_NAME }}" \
+                     --env TT_JIRA_TOKEN=${{ secrets.JIRA_TOKEN }} \
+                     --env TT_LOG_LEVEL="DEBUG" \
+                     --env TT_REPO_NAME="${{ env.REPO_NAME }}" \
+                     --env TT_SHOULD_TRACE_RESULTS_TO_JIRA=${{ inputs.trace_to_jira }} \
+                     --rm \
+                     ${{ steps.pull-test-traceability-image.outputs.TEST_TRACEABILITY_IMAGE }} \
+                     /bin/bash -c "poetry run pytest -k TestTraceTests"

--- a/.github/workflows/test_traceability.yml
+++ b/.github/workflows/test_traceability.yml
@@ -21,11 +21,12 @@ jobs:
 
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          mask-aws-account-id: true
 
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v1

--- a/.github/workflows/test_traceability.yml
+++ b/.github/workflows/test_traceability.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   test-traceability-job:
     name: Run test-traceability
-    runs-on: psga-prod-build
+    runs-on: ubuntu-22.04
     env:
       CONGENICA_AWS_ACCOUNT_DEV: 144563655722.dkr.ecr.eu-west-1.amazonaws.com
       REPO_NAME: psga-pipeline

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,28 @@
 [[package]]
+name = "allure-pytest"
+version = "2.13.2"
+description = "Allure pytest integration"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+allure-python-commons = "2.13.2"
+pytest = ">=4.5.0"
+
+[[package]]
+name = "allure-python-commons"
+version = "2.13.2"
+description = "Common module for integrate allure with python-based frameworks"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+attrs = ">=16.0.0"
+pluggy = ">=0.4.0"
+
+[[package]]
 name = "attrs"
 version = "22.1.0"
 description = "Classes Without Boilerplate"
@@ -491,9 +515,17 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "bd7d88dc78ecd14e78eddff68b6c22daf46977430c5725aec4cf8964380f6376"
+content-hash = "9b2caa0749902f0c97b816ae50a37739d8d547ed645463a0a5088af17592fe4e"
 
 [metadata.files]
+allure-pytest = [
+    {file = "allure-pytest-2.13.2.tar.gz", hash = "sha256:22243159e8ec81ce2b5254b4013802198821b1b42f118f69d4a289396607c7b3"},
+    {file = "allure_pytest-2.13.2-py3-none-any.whl", hash = "sha256:17de9dbee7f61c8e66a5b5e818b00e419dbcea44cb55c24319401ba813220690"},
+]
+allure-python-commons = [
+    {file = "allure-python-commons-2.13.2.tar.gz", hash = "sha256:8a03681330231b1deadd86b97ff68841c6591320114ae638570f1ed60d7a2033"},
+    {file = "allure_python_commons-2.13.2-py3-none-any.whl", hash = "sha256:2bb3646ec3fbf5b36d178a5e735002bc130ae9f9ba80f080af97d368ba375051"},
+]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
@@ -503,7 +535,14 @@ awscli = [
     {file = "awscli-1.22.50.tar.gz", hash = "sha256:9242401e539d62d9828e3168aebfd526bd64b2ad181fae007f7d8af26415b485"},
 ]
 biopython = [
+    {file = "biopython-1.79-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb3c25ac6688ceac074e8d09951d29d1ef49c0645f677550d7cbe5b950da5ccf"},
+    {file = "biopython-1.79-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d759ccb6e7539130f0b272bc246715cad2a2fb91520d62db183d62d65f80a215"},
+    {file = "biopython-1.79-cp310-cp310-win32.whl", hash = "sha256:1af4348c17e43f3c79a16af87424d8e3a32e2168ab9246106a085bbb2b8d3450"},
     {file = "biopython-1.79-cp310-cp310-win_amd64.whl", hash = "sha256:9eadfd4300f534cd4fa39613eeee786d2c3d6b981d373c5c46616fa1a97cad10"},
+    {file = "biopython-1.79-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1163ee42247d0ddb58838e5845de4b7b51012a48eb4b61e1f517edfeccab19db"},
+    {file = "biopython-1.79-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:535ca75060786a682e6572abdc42420fa8a54af388297da7c56d151c7cc63eec"},
+    {file = "biopython-1.79-cp311-cp311-win32.whl", hash = "sha256:6d1b8a63cb569209fb431d34dea0792d5c3ec0207aada3bdec3f8bf0c4a406fb"},
+    {file = "biopython-1.79-cp311-cp311-win_amd64.whl", hash = "sha256:0ead3c2df8fc4012fc7b1a2751be93c8b0fae677934e78d30182411ed34991bb"},
     {file = "biopython-1.79-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:72a1477cf1701964c7224e506a54fd65d1cc5228da200b634a17992230aa1cbd"},
     {file = "biopython-1.79-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:365569543ea58dd07ef205ec351c23b6c1a3200d5d321eb28ceaecd55eb5955e"},
     {file = "biopython-1.79-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4be31815226052d86d4c2f6a103c40504e34bba3e25cc1b1d687a3203c42fb6e"},
@@ -512,18 +551,24 @@ biopython = [
     {file = "biopython-1.79-cp36-cp36m-win_amd64.whl", hash = "sha256:98deacc30b8654cfcdcf707d93fa4e3c8717bbda07c3f9f828cf84753d4a1e4d"},
     {file = "biopython-1.79-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:884a2b99ac7820cb84f70089769a512e3238ee60438b8c934ed519613dc570ce"},
     {file = "biopython-1.79-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51eb467a60c38820ad1e6c3a7d4cb10535606f559646e824cc65c96091d91ff7"},
+    {file = "biopython-1.79-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26c8b935a08efc044bbdd8882b86800c6bd7aa2a22832cee9470aba708cd23b1"},
+    {file = "biopython-1.79-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3786ed9304f2de9f27a9eaa7d19b6b167eff2be0d15c99000a99785308b7dabe"},
     {file = "biopython-1.79-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:03ee5c72b3cc3f0675a8c22ce1c45fe99a32a60db18df059df479ae6cf619708"},
     {file = "biopython-1.79-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:9580978803b582e0612b71673cab289e6bf261a865009cfb9501d65bc726a76e"},
     {file = "biopython-1.79-cp37-cp37m-win32.whl", hash = "sha256:5ae69c5e09769390643aa0f8064517665df6fb99c37433821d6664584d0ecb8c"},
     {file = "biopython-1.79-cp37-cp37m-win_amd64.whl", hash = "sha256:f0a7e1d94a318f74974345fd0987ec389b16988ec484e67218e900b116b932a8"},
     {file = "biopython-1.79-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:aa23a83a220486af6193760d079b36543fe00afcfbd18280ca2fd0b2c1c8dd6d"},
     {file = "biopython-1.79-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b3d4eec2e348c3d97a7fde80ee0f2b8ebeed849d2bd64a616833a9be03b93c8"},
+    {file = "biopython-1.79-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:131093d8a0b8075b692fe73d9a4684d4fc98ff5990f6dce1e1b9f929c58207f1"},
+    {file = "biopython-1.79-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b5c371b54f9ebb9ec420d535748d40c6945faf829420c1c5b254b1b77f70b153"},
     {file = "biopython-1.79-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:947b793e804c59ea45ae46945a57612ad1789ca87af4af0d6a62dcecf3a6246a"},
     {file = "biopython-1.79-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d9f6ce961e0c380e2a5435f64c96421dbcebeab6a1b41506bd81251feb733c08"},
     {file = "biopython-1.79-cp38-cp38-win32.whl", hash = "sha256:155c5b95857bca7ebd607210cb9d8ea459bb0b86b3ca37ea44ec47c26ede7e9a"},
     {file = "biopython-1.79-cp38-cp38-win_amd64.whl", hash = "sha256:2dbb4388c75b5dfca8ce729e791f465c9c878dbd7ba2ab9a1f9854609d2b5426"},
     {file = "biopython-1.79-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:76988ed3d7383d566db1d7fc69c9cf136c6275813fb749fc6753c340f81f1a8f"},
     {file = "biopython-1.79-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e921571b51514a6d35944242d6fef6427c3998acf58940fe1f209ac8a92a6e87"},
+    {file = "biopython-1.79-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b385ab3eb8921bdf952213bb94c52662696905e5e5b8b81b024156eec3249012"},
+    {file = "biopython-1.79-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:465429ca6fc1a98d25cc7a15708f1d238caa3ada66c3cd47d27405c816c80808"},
     {file = "biopython-1.79-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bf634a56f449a4123e48e538d661948e5ac29fb452acd2962b8cb834b472a9d7"},
     {file = "biopython-1.79-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ab93d5749b375be3682866b3a606aa2ebd3e6d868079793925bf4fbb0987cf1f"},
     {file = "biopython-1.79-cp39-cp39-win32.whl", hash = "sha256:8f33dafd3c7254fff5e1684b965e45a7c08d9b8e1bf51562b0a521ff9a6f5ea0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,15 @@ structlog = "21.5.0"
 urllib3 = "1.26.14"
 GitPython = "3.1.29"
 pyahocorasick = "1.4.4"
+allure-pytest = "^2.13.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "7.1.3"
+
+[tool.pytest.ini_options]
+markers = [
+    "jira: A marker that allows a test to be associated with a story/task in Jira (for traceability purposes).",
+]
 
 [build-system]
 requires = ["poetry-core==1.0.8"]

--- a/tests/common/test_check_metadata.py
+++ b/tests/common/test_check_metadata.py
@@ -41,6 +41,7 @@ from tests.util.test_notification import load_log_file_to_dict
         ),
     ],
 )
+@pytest.mark.jira(identifier="5ef0808f-a41a-4ea9-abb1-c46d620a0247", confirms="PSG-3621")
 def test_validate_metadata(
     check_metadata_data_path: Path,
     metadata_file: str,
@@ -236,6 +237,7 @@ def test_validate_metadata(
         ),
     ],
 )
+@pytest.mark.jira(identifier="53c2d945-92e5-4f92-b256-3891fca6bb18", confirms="PSG-3621")
 def test_check_metadata(
     tmp_path: Path,
     check_metadata_data_path: Path,

--- a/tests/common/test_concat_csv.py
+++ b/tests/common/test_concat_csv.py
@@ -9,18 +9,21 @@ from scripts.util.metadata import SAMPLE_ID
 from tests.utils_tests import assert_csvs_are_equal
 
 
+@pytest.mark.jira(identifier="841d3e5c-65ea-4db2-8247-713dc550ac32", confirms="PSG-3621")
 def test_concat_no_file_found_error(tmp_path: Path):
     output_csv_path = Path(tmp_path / "concat.csv")
     with pytest.raises(FileNotFoundError, match="No matching file was found"):
         concat(input_path=tmp_path, output_csv_path=output_csv_path)
 
 
+@pytest.mark.jira(identifier="edd1fee1-2b71-4c4f-bf45-c8de604610cc", confirms="PSG-3621")
 def test_concat_column_not_found_error(tmp_path: Path, concat_csv_data_path: Path):
     output_csv_path = Path(tmp_path / "concat.csv")
     with pytest.raises(ValueError, match="Column 'fake' needed for sorting"):
         concat(input_path=concat_csv_data_path, output_csv_path=output_csv_path, sortby_col="fake")
 
 
+@pytest.mark.jira(identifier="e9b930ec-9b72-401c-8933-bc17d2fd5238", confirms="PSG-3621")
 def test_concat(tmp_path: Path, concat_csv_data_path: Path):
     output_csv_path = Path(tmp_path / "concat.csv")
     expected_output_csv_path = Path(concat_csv_data_path / "expected_output" / "result.csv")
@@ -40,6 +43,7 @@ def test_concat(tmp_path: Path, concat_csv_data_path: Path):
     )
 
 
+@pytest.mark.jira(identifier="7aaa925b-e92a-49a7-b0df-0a781b25d9c5", confirms="PSG-3621")
 def test_concat_csv(tmp_path: Path, concat_csv_data_path: Path):
 
     output_csv_path = Path(tmp_path / "concat.csv")

--- a/tests/common/test_contamination_removal.py
+++ b/tests/common/test_contamination_removal.py
@@ -28,6 +28,7 @@ def assert_rik_output_csv(output_path: Path, expected_rik_output_csv: dict[str, 
         "rik_output_two_reads_exception.txt",
     ],
 )
+@pytest.mark.jira(identifier="16c0752b-146f-4ea1-ab63-4fc2c04d6575", confirms="PSG-3621")
 def test_get_contaminated_reads_exception(contamination_removal_data_path: Path, input_file: str):
     input_path = contamination_removal_data_path / input_file
     with pytest.raises(ValueError, match="cannot be negative"):
@@ -41,6 +42,7 @@ def test_get_contaminated_reads_exception(contamination_removal_data_path: Path,
         ("rik_output_two_reads.txt", 696),
     ],
 )
+@pytest.mark.jira(identifier="80d91164-7c98-4399-80ef-821627f8336f", confirms="PSG-3621")
 def test_get_contaminated_reads(
     contamination_removal_data_path: Path, input_file: str, expected_contaminated_reads: int
 ):
@@ -69,6 +71,7 @@ def test_get_contaminated_reads(
         ),
     ],
 )
+@pytest.mark.jira(identifier="12f810d0-8760-4e33-8912-db5dfff59675", confirms="PSG-3621")
 def test_write_rik_output_csv(
     tmp_path: Path, sample_id: str, contaminated_reads: int, expected_rik_output_csv: dict[str, str]
 ):
@@ -98,6 +101,7 @@ def test_write_rik_output_csv(
         ),
     ],
 )
+@pytest.mark.jira(identifier="15090941-15df-46d2-9a5d-5ffd660818d4", confirms="PSG-3621")
 def test_process_rik(
     tmp_path: Path,
     contamination_removal_data_path: Path,
@@ -132,6 +136,7 @@ def test_process_rik(
         ),
     ],
 )
+@pytest.mark.jira(identifier="5fb18309-ccdf-44ce-852d-d723d767b180", confirms="PSG-3621")
 def test_contamination_removal(
     tmp_path: Path,
     contamination_removal_data_path: Path,

--- a/tests/common/test_fetch_primers.py
+++ b/tests/common/test_fetch_primers.py
@@ -113,6 +113,7 @@ def rmfile(filepath: Path, filename: str) -> None:
         "quick-lab, artic v5.3.2-400 (source primer bed with mispelled name)",
     ],
 )
+@pytest.mark.jira(identifier="337f1ac9-8b1c-4ccd-ae61-b7a7fa482b4a", confirms="PSG-3621")
 def test_extract_primer_sequences(
     tmp_path: Path,
     primer_data: dict,
@@ -139,6 +140,7 @@ def test_extract_primer_sequences(
     assert_files_are_equal(scheme_fasta_path, expected_scheme_fasta_path)
 
 
+@pytest.mark.jira(identifier="ee8f4c43-c5d4-4904-8ef3-ef72035b5c5d", confirms="PSG-3621")
 def test_extract_primer_sequences_unknown_strand_error(
     tmp_path: Path,
     fetch_primers_data_path: Path,
@@ -170,6 +172,7 @@ def test_extract_primer_sequences_unknown_strand_error(
         f"Missing {REFERENCE} {FASTA} file",
     ],
 )
+@pytest.mark.jira(identifier="b048656c-163a-4aec-bc76-83ad39491d12", confirms="PSG-3621")
 def test_extract_primer_sequences_file_not_found_error(
     tmp_path: Path,
     primer_data: dict,
@@ -202,6 +205,7 @@ def test_extract_primer_sequences_file_not_found_error(
         QUICK_LAB,
     ],
 )
+@pytest.mark.jira(identifier="7ba24142-060d-4b50-9100-0243d92c4231", confirms="PSG-3621")
 def test_organise_primers(
     tmp_path: Path,
     primer_schemes_dir: str,

--- a/tests/common/test_primer_autodetection.py
+++ b/tests/common/test_primer_autodetection.py
@@ -161,6 +161,7 @@ def assert_primer_automaton(
         f"{SARS_COV_2}_primer_index.csv",
     ],
 )
+@pytest.mark.jira(identifier="7ea6a401-37f4-4e7d-8c99-b1b4276adfa1", confirms="PSG-3621")
 def test_build_primers_automaton(
     tmp_path: Path,
     primer_autodetection_primer_schemes_data_path: Path,
@@ -192,6 +193,7 @@ def test_build_primers_automaton(
         )
     ],
 )
+@pytest.mark.jira(identifier="5d595f04-ef60-4c98-ae45-14000dbb4143", confirms="PSG-3621")
 def test_count_primer_matches(
     primer_autodetection_sample_dir_data_path: Path,
     sample: str,
@@ -261,6 +263,7 @@ def test_count_primer_matches(
         ),
     ],
 )
+@pytest.mark.jira(identifier="2116ec3e-87c2-40e3-bd70-aa369d4d79e2", confirms="PSG-3621")
 def test_compute_primer_data(
     primer_autodetection_sample_dir_data_path: Path,
     primers_automaton_fixture: dict[str, PrimerAutomaton],
@@ -288,6 +291,7 @@ def test_compute_primer_data(
         ),
     ],
 )
+@pytest.mark.jira(identifier="61bf55d8-2717-44ce-bea9-f9ef6c05ee73", confirms="PSG-3621")
 def test_generate_metrics(
     tmp_path: Path,
     primer_autodetection_data_path: Path,
@@ -320,6 +324,7 @@ def test_generate_metrics(
         ("not_found", "a0446f6f-7d24-478c-8d92-7c77036930d8", UNKNOWN, 0, "none", DEFAULT_PRIMER),
     ],
 )
+@pytest.mark.jira(identifier="f370404a-c340-4677-bc83-507657db0d80", confirms="PSG-3621")
 def test_select_primer(
     tmp_path: Path,
     primer_autodetection_data_path: Path,
@@ -347,6 +352,7 @@ def test_select_primer(
         ("not_found", "a0446f6f-7d24-478c-8d92-7c77036930d8", "unknown"),
     ],
 )
+@pytest.mark.jira(identifier="a52a1a34-0d96-405c-8782-4cdfcf7be06e", confirms="PSG-3621")
 def test_write_primer_data(
     tmp_path: Path,
     primer_autodetection_data_path: Path,
@@ -368,6 +374,7 @@ def test_write_primer_data(
         ("not_found", "a0446f6f-7d24-478c-8d92-7c77036930d8", DEFAULT_PRIMER),
     ],
 )
+@pytest.mark.jira(identifier="6831b9e0-7803-419f-8e08-0d554d1f6cf5", confirms="PSG-3621")
 def test_write_selected_primer(
     tmp_path: Path,
     primer_autodetection_data_path: Path,
@@ -386,6 +393,7 @@ def test_write_selected_primer(
         ("not_found", "a0446f6f-7d24-478c-8d92-7c77036930d8", "unknown"),
     ],
 )
+@pytest.mark.jira(identifier="7d937435-6fda-49dc-80c2-1e74142a8d65", confirms="PSG-3621")
 def test_generate_primer_autodetection_output_files(
     tmp_path: Path,
     primer_autodetection_data_path: Path,
@@ -408,6 +416,7 @@ def test_generate_primer_autodetection_output_files(
         (f"{SARS_COV_2}_primer_index.csv", "a0446f6f-7d24-478c-8d92-7c77036930d8", "unknown"),
     ],
 )
+@pytest.mark.jira(identifier="e4021c9e-609f-45b5-b366-9943b1146148", confirms="PSG-3621")
 def test_primer_autodetection(
     tmp_path: Path,
     primer_autodetection_data_path: Path,

--- a/tests/common/test_reheader_fasta.py
+++ b/tests/common/test_reheader_fasta.py
@@ -19,6 +19,7 @@ from scripts.common.reheader_fasta import reheader_fasta, FASTA_FILE_EXTENSION, 
         ">{sample_id}|5524211|gb|AAD44166.1| cytochrome b [Elephas maximus maximus]",
     ],
 )
+@pytest.mark.jira(identifier="83399fd1-3412-4aac-b602-0004d11424c4", confirms="PSG-3621")
 def test_reheader_fasta(tmp_path: Path, fasta_file_generator: Callable, input_fasta_header: str):
 
     fasta_file_generator(

--- a/tests/integration_tests/test_compare.py
+++ b/tests/integration_tests/test_compare.py
@@ -33,6 +33,7 @@ from integration_tests.compare import compare_output_files_set, ValidationError
         ),
     ],
 )
+@pytest.mark.jira(identifier="73dcd85e-163a-4e2b-8644-cfbc4d263abb", confirms="PSG-3621")
 def test_compare_output_files_set(calc_output_files: set[str], exp_output_files: set[str], exc: str):
     if exc:
         with pytest.raises(ValidationError, match=exc):

--- a/tests/integration_tests/test_loading.py
+++ b/tests/integration_tests/test_loading.py
@@ -62,6 +62,7 @@ from tests.integration_tests.util import create_paths
         ),
     ],
 )
+@pytest.mark.jira(identifier="69e0f0ab-f1f5-4e4d-aaaf-a6ad78b06522", confirms="PSG-3621")
 def test_load_data_from_csv(
     tmp_path: Path, integration_test_validation_data_path: Path, pathogen: str, csv_file: str, config: dict, exc: str
 ):
@@ -90,6 +91,7 @@ def test_load_data_from_csv(
         ["a", "b", "c"],
     ],
 )
+@pytest.mark.jira(identifier="c0de6e77-b6c4-42d5-9d2b-fd0ccb1aaa35", confirms="PSG-3621")
 def test_get_file_paths(tmp_path, path_list):
     paths = [os.path.join(tmp_path, f) for f in path_list]
     create_paths(paths)

--- a/tests/integration_tests/test_validation.py
+++ b/tests/integration_tests/test_validation.py
@@ -47,6 +47,7 @@ def create_output_files(pathogen: str, samples: Path, root: Path, sequencing_tec
         ),
     ],
 )
+@pytest.mark.jira(identifier="62e11544-ba67-4124-8b8f-c23418b37881", confirms="PSG-3621")
 def test_compare_merged_output_file(
     integration_test_validation_data_path: Path,
     pathogen: str,
@@ -99,6 +100,7 @@ def test_compare_merged_output_file(
         ),
     ],
 )
+@pytest.mark.jira(identifier="9020247d-84ec-446d-98c8-4de0b39e8c4d", confirms="PSG-3621")
 def test_validation(
     tmp_path: Path,
     integration_test_validation_data_path: Path,

--- a/tests/sars_cov_2/test_extract_typing_data.py
+++ b/tests/sars_cov_2/test_extract_typing_data.py
@@ -1,3 +1,4 @@
+import pytest
 from pathlib import Path
 from click.testing import CliRunner
 
@@ -5,6 +6,7 @@ from scripts.sars_cov_2.extract_typing_data import extract_typing_data
 from scripts.util.data_loading import load_yaml
 
 
+@pytest.mark.jira(identifier="84e2a22c-3be7-4ac0-9418-e9e5f5a90790", confirms="PSG-3621")
 def test_extract_typing_data(tmp_path: Path, typing_data_path: Path, variant_definitions_data_path: Path):
 
     output_yaml_path = tmp_path / "definitions.yaml"

--- a/tests/sars_cov_2/test_generate_pipeline_results_files_sars_cov_2.py
+++ b/tests/sars_cov_2/test_generate_pipeline_results_files_sars_cov_2.py
@@ -55,6 +55,7 @@ from tests.utils_tests import assert_csvs_are_equal, assert_jsons_are_equal
         ),
     ],
 )
+@pytest.mark.jira(identifier="b3573927-a7d0-43a3-83b1-dd1e61f21859", confirms="PSG-3621")
 def test_generate_pipeline_results_files(
     tmp_path: Path,
     pipeline_results_files_data_path: Path,

--- a/tests/synthetic/test_generate_pipeline_results_files_synthetic.py
+++ b/tests/synthetic/test_generate_pipeline_results_files_synthetic.py
@@ -36,6 +36,7 @@ from tests.utils_tests import assert_csvs_are_equal, assert_jsons_are_equal
         ),
     ],
 )
+@pytest.mark.jira(identifier="1b81ce66-aa70-438e-986f-3684aaed652e", confirms="PSG-3621")
 def test_generate_pipeline_results_files(
     tmp_path: Path,
     pipeline_results_files_data_path: Path,

--- a/tests/util/test_convert.py
+++ b/tests/util/test_convert.py
@@ -21,6 +21,7 @@ from tests.utils_tests import assert_jsons_are_equal
         ),
     ],
 )
+@pytest.mark.jira(identifier="102bd1eb-18ec-4c15-b92e-f0ba55ccf61a", confirms="PSG-3621")
 def test_csv_to_json(
     tmp_path: Path,
     pipeline_results_files_data_path: Path,

--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -19,6 +19,7 @@ from tests.util.test_notification import load_log_file_to_dict
     "level",
     [level.lower() for level in LOG_LEVELS],
 )
+@pytest.mark.jira(identifier="f0126ecb-25fa-4880-8ec3-ffc2125f488c", confirms="PSG-3621")
 def test_logger(tmp_path: Path, message: str, level: str, sample: str):
     log_file = tmp_path / "messages.log"
     assert not log_file.is_file()

--- a/tests/util/test_notification.py
+++ b/tests/util/test_notification.py
@@ -66,6 +66,7 @@ def load_log_file_to_dict(log_file: Path, key: str) -> dict:
         },
     ],
 )
+@pytest.mark.jira(identifier="e3e580c9-ad11-4567-a0b1-49fe467b6f22", confirms="PSG-3621")
 def test_notification(tmp_path: Path, events: dict[str, Event]):
 
     log_file = tmp_path / "messages.log"

--- a/tests/util/test_slugs.py
+++ b/tests/util/test_slugs.py
@@ -13,6 +13,7 @@ from scripts.util.slugs import get_file_with_type, FileType
     ],
 )
 @pytest.mark.parametrize("sample_id", ["roger", "clio"])
+@pytest.mark.jira(identifier="aa8c8f26-fd37-41ef-b003-7aec00b71728", confirms="PSG-3621")
 def test_get_file_with_type(
     output_path: str,
     inner_dirs: list[str],


### PR DESCRIPTION
## What does this PR do?

This PR enables test traceability on this repo, allowing all tests for the PSGA pipeline to be traced back to Jira work items. It's worth noting that the approach here is identical to how tests are managed in all other PSGA focused repos.

A few notes:

- This PR just focuses on the GitHub Actions pipeline; the CircleCI pipeline will come in a second PR
- I've added `allure-pytest` as a dependency to the project, allowing `pytest` to generate a set of Allure Results that are then copied to an S3 bucket
- A new `test_traceability` workflow has been added to GitHub Actions, which:
  - Only parses the results generated on non-release branches to check they are valid and can be ingested by the test traceability framework
  - Goes one step further for release branches and records the results of the tests in Jira, which is then used to generate traceability reports against the requirements
- For the Allure Results to contain the information necessary, I've added a `jira` marker to the tests and linked them back to [this work item in Jira](https://jira.congenica.net/browse/PSG-3621)

For more information on test traceability in general, please see [this documentation](https://confluence.congenica.net/display/TEST/Test+Traceability).

## Testing

The GitHub Actions workflows for this PR are passing. I can also confirm the Allure Results generated by this repo are correctly being copied into the S3 bucket:

```
➜ aws s3 ls s3://psga-artefacts/allure-results/psga-pipeline/
2023-06-16 12:04:58     206101 376686a3d78a8cb7d085b62431d29d7985ce1d0e_0.tar.gz
2023-06-16 13:12:53     204948 376686a3d78a8cb7d085b62431d29d7985ce1d0e_1.tar.gz
2023-06-16 11:44:01     206824 f8d4968e328578328b6b8b3f7c4a36db0184b16b_0.tar.gz
```