### PR TITLE
Fix: Trace tests back to Jira on builds from `main`

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -69,4 +69,4 @@ jobs:
     secrets: inherit
     with:
       docker_tag: dev_latest
-      trace_to_jira: false
+      trace_to_jira: ${{ github.ref == 'refs/heads/main' && true || false }}

--- a/.github/workflows/release_branch.yml
+++ b/.github/workflows/release_branch.yml
@@ -89,10 +89,3 @@ jobs:
 
       - name: Push the release image to prod
         run: docker push $PROD_RELEASE_NAME
-
-  test_traceability:
-    uses: ./.github/workflows/test_traceability.yml
-    secrets: inherit
-    with:
-      docker_tag: dev_latest
-      trace_to_jira: true


### PR DESCRIPTION
## What does this PR do?

This PR changes the tracing of tests back to Jira on builds of the tests from `main`. It was originally from `release/*` branches but it's much more useful to have the tracing to Jira executed after we've merged to `main` as we can then generate traceability reports ahead of the release (instead of having to wait for a `release/*` branch to be created).

It also removes a step from the release workflow in GitHub Actions and reduces the risk of something going wrong at that stage.

## Testing

No need as the change is minimal and I've confirmed that this identical syntax works for the `psga-backend` repo in [this PR](https://github.com/Congenica/psga-backend/pull/894).