### PR TITLE
Fix: Test traceability repository path

### DIFF
--- a/.github/workflows/test_traceability.yml
+++ b/.github/workflows/test_traceability.yml
@@ -54,7 +54,7 @@ jobs:
                      --env TT_ALLURE_RESULTS_S3_URL="$BUCKET_URL_FULL" \
                      --env TT_JIRA_COMPONENT="Pipelines" \
                      --env TT_JIRA_PROJECT_KEY="PSG" \
-                     --env TT_JIRA_TEST_REPOSITORY_PATH="${{ env.REPO_NAME }}" \
+                     --env TT_JIRA_TEST_REPOSITORY_PATH="${{ env.REPO_NAME }}/unit" \
                      --env TT_JIRA_TOKEN=${{ secrets.JIRA_TOKEN }} \
                      --env TT_LOG_LEVEL="DEBUG" \
                      --env TT_REPO_NAME="${{ env.REPO_NAME }}" \


### PR DESCRIPTION
The test traceability framework expects tests in Xray to be under a `{repo_name}/{test_type}` structure. For example:

- `psga-backend/unit`
- `psga-system-testing/scalability`

The `psga-pipeline` tests did not have a `test_type` declared in the config.