### PR TITLE
PSG-4630 Find samples.csv via --config-path

### DIFF
--- a/psga/common/help.nf
+++ b/psga/common/help.nf
@@ -22,7 +22,7 @@ def printMainConfig() {
         * NXF_OPTS                                    : ${NXF_OPTS}
 
         Global parameters:
-        * metadata                                    : ${params.metadata}
+        * config-path                                 : ${params.configPath}
         * run                                         : ${params.run}
         * sequencing_technology                       : ${params.sequencing_technology}
         * kit                                         : ${params.kit}
@@ -71,7 +71,7 @@ def printMainHelp() {
         NXF_OPTS                Pass JVM options to Nextflow (default: -Xms1g -Xmx4g)
 
       Mandatory parameters:
-        --metadata              The path to the metadata file. This can be an s3 path
+        --config-path           The path to the config directory which holds sample, reference data description files. This can be an s3 path
         --run                   A (unique) string identifying the analysis run (batch)
         --sequencing_technology The technology used for sequencing the samples. Values: 'illumina', 'ont', 'unknown'
         --kit                   The kit used for sequencing the samples (e.g. the scheme version of the primers)

--- a/psga/common/organise_metadata_sample_files.nf
+++ b/psga/common/organise_metadata_sample_files.nf
@@ -15,11 +15,11 @@ if ( params.sequencing_technology == "illumina" ) {
 }
 
 /*
- * process the metadata.csv and organise sample files in channels.
+ * process the samples.csv and organise sample files in channels.
  */
 workflow organise_metadata_sample_files {
     main:
-        check_metadata(params.metadata)
+        check_metadata("${params.configPath}samples.csv")
         ch_metadata = check_metadata.out.ch_metadata
 
         // organise sample input files by file type

--- a/psga/main.nf
+++ b/psga/main.nf
@@ -63,8 +63,8 @@ if( NXF_EXECUTOR == "k8s" && "[:]" in [
 if ( params.run == "" ) {
     throw new Exception("Error: '--run' must be defined")
 }
-if ( params.metadata == "" ) {
-    throw new Exception("Error: '--metadata' must be defined")
+if ( params.configPath == "" ) {
+    throw new Exception("Error: '--config-path' must be defined")
 }
 if ( params.sequencing_technology == "" ) {
     throw new Exception("Error: '--sequencing_technology' must be defined")


### PR DESCRIPTION
The --config-path argument is now always passed to pipelines. 

We should use it in the sars-cov-2 pipeline to locate the samples.csv file. This is reducing the usage of the 
--metdata commend line argument so it can be removed.

The point of this is that the --config-path argument is more extensible as we can add additional files to the path without having to modifying the command line execution model or pipelines that aren't interested in additional files.

(so for settings, we can just write a settings file in the --config-path directory and those pipelines that are interested can use it)