### PR TITLE
PSG-4695 Temporary fix - Ensure `metadata.csv` does not contain unexpected columns

### DIFF
--- a/psga/config/psga-schema-sars-cov-2.yaml
+++ b/psga/config/psga-schema-sars-cov-2.yaml
@@ -374,26 +374,10 @@ pipeline:
 pipeline_version:
   docker_tag: dev_latest
 
-input_fields:
-  - field_name: file_1_type
-    field_type: string
-    required: true
-    read_only: true
-    validation_rules:
-      - rule_type: not_null
+input_fields: []
 
-  - field_name: file_2_type
-    field_type: string
-    required: false
-    read_only: true
-    validation_rules:
-      - rule_type: not_null
-
-#input_row_validation_rules:
-#- {}
-#
-#input_set_validation_rules:
-#- {}
+# input_row_validation_rules: []
+# input_set_validation_rules: []
 
 output_fields:
   - field_name: STATUS
@@ -623,8 +607,6 @@ output_fields:
     ui:
       name: "Pangolin Note"
     required: true
-#output_row_validation_rules:
-#- {}
-#
-#output_set_validation_rules:
-#- {}
+
+# output_row_validation_rules: []
+# output_set_validation_rules: []


### PR DESCRIPTION
`file_1_type` and `file_2_type` were moved from the Analysis Type Definition to the Pipeline Definition in https://github.com/Congenica/psga-backend/pull/1133/commits/da31ba320d12a3b809d4796e613e0d9840989c9f

This makes the`psga-backend` `assemble_metadata()` function that creates the `metadata.csv` file for the pipeline put `file_1_type` and `file_2_type` in the CSV file. SARS-CoV-2 has strong expectations about the contents of the CSV and fails when it finds these extra columns.

This PR is the pair of https://github.com/Congenica/psga-backend/pull/1149