### PR TITLE
RT-363: Update GitHub workflows to upload Allure Results to new S3 bucket

### DIFF
--- a/.github/workflows/check_and_test.yaml
+++ b/.github/workflows/check_and_test.yaml
@@ -54,7 +54,7 @@ jobs:
       #   - etc
       - name: Compress Allure Results
         run: |
-          ARTIFACT_S3_PATH_PARTIAL=s3://psga-artefacts/allure-results/psga-pipeline
+          ARTIFACT_S3_PATH_PARTIAL=s3://congenica-test-evidence/psga-pipeline/unit
           ARTIFACT_COUNT=$(aws s3 ls $ARTIFACT_S3_PATH_PARTIAL/${{ github.sha }} | wc -l)
           ARTIFACT_NAME=${{ github.sha }}_$ARTIFACT_COUNT.tar.gz
           ARTIFACT_PATH=${{ github.workspace }}/$ARTIFACT_NAME

--- a/.github/workflows/test_traceability.yml
+++ b/.github/workflows/test_traceability.yml
@@ -49,7 +49,7 @@ jobs:
       # two builds executing against a single branch on the same Git hash is highly unlikely.
       - name: Run test traceability
         run: |
-          BUCKET_URL_ROOT=s3://psga-artefacts/allure-results/${{ env.REPO_NAME }}
+          BUCKET_URL_ROOT=s3://congenica-test-evidence/${{ env.REPO_NAME }}/unit
           BUCKET_URL_PARTIAL=$BUCKET_URL_ROOT/${{ github.sha }}
           ALLURE_ARTIFACT_NAME=$(aws s3 ls $BUCKET_URL_PARTIAL | awk '{print $4}' | tail -n1)
           BUCKET_URL_FULL=$BUCKET_URL_ROOT/$ALLURE_ARTIFACT_NAME


### PR DESCRIPTION
## What does this PR do?

I've wanted to centralise the storing of test evidence from all Congenica products in a single S3 bucket. This will allow the generation of reports around test evidence to be centralised and automated more easily.

I [requested a new bucket](https://jira.congenica.net/browse/SAP-34143) from the Ops team, which they created a while ago. This bucket is reachable from the Congenica dev AWS account (144563655722) and from the PSGA dev AWS account (566277102435), meaning the:

- Pods that Jenkins spins up in clusters that belong to either account can read from and write to this bucket.
- GitHub runners on the PSGA side can read from and write to this bucket.

Therefore, this PR updates the S3 bucket in the GitHub Actions workflow where the Allure Results are uploaded to and where the test traceability workflow downloads them from.

Note [this Slack thread](https://congenica.slack.com/archives/C0433NVB1A5/p1698395289970699) that resulted in the AWS keys being updated for this repo so it can see the new S3 bucket.

## Testing

The GitHub Actions pipeline is green and you can also see it is publishing the Allure Results for the unit tests to the new S3 bucket:

```
➜ aws s3 ls s3://congenica-test-evidence/psga-pipeline/unit/
2023-10-27 08:55:18     203686 c6346844f68e2ea45bf7b6ca2d0eb81a5b8b1826_0.tar.gz
```