### PR TITLE
PSG-4617 Setting - Add `slug` to Pipeline Definition files

### DIFF
--- a/psga/config/psga-schema-s-aureus.yaml
+++ b/psga/config/psga-schema-s-aureus.yaml
@@ -1,6 +1,7 @@
 ---
 pipeline:
   name: Staphylococcus aureus
+  slug: s-aureus
   docker_image: "s-aureus-pipeline"
 
 pipeline_version:

--- a/psga/config/psga-schema-sars-cov-2.yaml
+++ b/psga/config/psga-schema-sars-cov-2.yaml
@@ -1,6 +1,7 @@
 ---
 pipeline:
   name: SARS CoV 2
+  slug: sars-cov-2
   docker_image: "sars-cov-2-pipeline"
 
 pipeline_version:

--- a/psga/config/psga-schema-synthetic.yaml
+++ b/psga/config/psga-schema-synthetic.yaml
@@ -1,6 +1,7 @@
 ---
 pipeline:
   name: Synthetic
+  slug: synthetic
   docker_image: "synthetic-pipeline"
 
 pipeline_version:


### PR DESCRIPTION
This PR relates to work in https://github.com/Congenica/psga-backend/pull/1205

We are now storing the Pipeline `slug` in the database, so we want the Pipeline Definition files to be self-contained and specify the `slug` rather than relying on the filename.