### PR TITLE
PSG-4787 create release versions in dev

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -1,8 +1,7 @@
 name: Build, test and push pipeline images
 on:
   push:
-    branches-ignore:
-      - "release/**"
+
 jobs:
   check_and_test:
     name: Install dependencies and run tests

--- a/.github/workflows/publish_configs.yaml
+++ b/.github/workflows/publish_configs.yaml
@@ -2,10 +2,6 @@ name: Publish config files
 on:
   workflow_call:
     inputs:
-      release_enabled:
-        type: boolean
-        default: false
-        required: false
       actions_env:
         type: string
         default: nonprod
@@ -69,12 +65,10 @@ jobs:
         run: |
           curl -Ls https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -o /usr/local/bin/yq && \
             chmod +x /usr/local/bin/yq
-          if [[ "${{ inputs.release_enabled }}" == "true" ]]; then
-            RELEASE_VERSION=${GITHUB_REF/refs\/heads\/release\//}
-            VERSIONS="${RELEASE_VERSION}"
+          if [[ "${GITHUB_REF/refs\/heads\/}" == *"release/"* ]]; then
+            VERSIONS="${GITHUB_REF/refs\/heads\/release\//}"
           else
-            BRANCH_NAME=${GITHUB_REF/refs\/heads\//}
-            VERSIONS="${{ github.sha }} ${BRANCH_NAME}_latest"
+            VERSIONS="${{ github.sha }} ${GITHUB_REF/refs\/heads\//}_latest"
           fi
           for version in $VERSIONS; do
             for config in $(ls app/config); do

--- a/.github/workflows/release_branch.yml
+++ b/.github/workflows/release_branch.yml
@@ -33,7 +33,6 @@ jobs:
       GH_PSGA_SYSTEM_PAT: ${{ secrets.GH_PSGA_SYSTEM_PAT }}
     with:
       actions_env: prod
-      release_enabled: true
 
   start-runner:
     uses: Congenica/psga-reusable-workflows/.github/workflows/ec2-runner-start.yaml@main


### PR DESCRIPTION
Currently release branch versions are not created for the dev environment, only the prod environment, which means that we can't test these in dev when we're automatically running tests against a new patched version of the release software in the dev env.

This change will mean that the pipeline workflow will run for release branches and will always create the a version for the release branch, not only if release_enabled is passed as true, so I've removed the release_enabled input as it's no longer required.